### PR TITLE
Fix mbedtls

### DIFF
--- a/recipes-connectivity/mbedtls/mbedtls_%.bbappend
+++ b/recipes-connectivity/mbedtls/mbedtls_%.bbappend
@@ -1,6 +1,7 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 SRCREV = "e089f6f2d06091def48ff610b099efb1c1a1aaca"
+PV = "2.28.0"
 SRC_URI = "git://github.com/EVerest/ext-mbedtls.git;protocol=https;branch=mbedtls-2.28.0-trustedCAKey"
 SRC_URI += " \
     file://0001-Add-pkg-config-file.patch \


### PR DESCRIPTION
The .bbappend was fixed to version 2.28.0. meta-openembedded has upgraded mbedtls in 60e8a5e23a82838b731812837ec1d170fb9ddccb to use version 2.28.2 which caused a problem that the .bbappend cannot find the default recipe. This is fixed by removing the reference to a fixed version in the .bbappend name.