### PR TITLE
update mbedtls

### DIFF
--- a/recipes-connectivity/mbedtls/mbedtls_%.bbappend
+++ b/recipes-connectivity/mbedtls/mbedtls_%.bbappend
@@ -1,6 +1,6 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
-SRCREV = "e089f6f2d06091def48ff610b099efb1c1a1aaca"
+SRCREV = "ef1a43f80ce630c48eb9366410275b6fdf2c51a2"
 PV = "2.28.0"
 SRC_URI = "git://github.com/EVerest/ext-mbedtls.git;protocol=https;branch=mbedtls-2.28.0-trustedCAKey"
 SRC_URI += " \


### PR DESCRIPTION
The mbedtls fork (mbedtls-2.28.0-trustedCAKey) gained bugfixes and improvements on the TLS server side.