### PR TITLE
Update kirkstone to EVerest 2024.1.0 release

### DIFF
--- a/recipes-core/everest/everest-core_2024.1.0.bb
+++ b/recipes-core/everest/everest-core_2024.1.0.bb
@@ -7,7 +7,7 @@ SRC_URI = "git://github.com/EVerest/everest-core.git;branch=main;protocol=https 
 
 S = "${WORKDIR}/git"
 
-SRCREV = "6c3e62c4e48186397b3c3154d16e7ef64322a17b"
+SRCREV = "0ef304736dbec70e7c2811a329d57c997547cd3f"
 
 do_compile[network] = "1"
 

--- a/recipes-core/everest/libevse-security_0.4.2.bb
+++ b/recipes-core/everest/libevse-security_0.4.2.bb
@@ -7,7 +7,7 @@ inherit cmake
 
 S = "${WORKDIR}/git"
 
-SRCREV = "e564e87e515b254af9dbdf9aaee5c435ebdde1e4"
+SRCREV = "5afe436231a017f7c7ce4822d20c964b48e9ae40"
 
 DEPENDS = "\
     everest-cmake \

--- a/recipes-core/everest/libocpp_0.9.7.bb
+++ b/recipes-core/everest/libocpp_0.9.7.bb
@@ -7,7 +7,7 @@ inherit cmake
 
 S = "${WORKDIR}/git"
 
-SRCREV = "1ecd9cd585eab66008894864600e6890b84c79c7"
+SRCREV = "bef3f61501bf1c352746c6a609281c4f5c341707"
 
 DEPENDS = "\
     everest-cmake \


### PR DESCRIPTION
We compiled with our chargebyte internal CI and tested the build on our Tarragon platform.
