### PR TITLE
mbedtls: fix LICENSE and LIC_FILES_CHKSUM in bbappend

### DIFF
--- a/recipes-connectivity/mbedtls/mbedtls_%.bbappend
+++ b/recipes-connectivity/mbedtls/mbedtls_%.bbappend
@@ -7,4 +7,7 @@ SRC_URI += " \
     file://0001-Add-pkg-config-file.patch \
 "
 
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
+
 inherit pkgconfig


### PR DESCRIPTION
The bbappend sticks the mbedtls library to an older version.

Meanwhile, the upstream license is a dual one which is also reflected in the upstream's recipe [1] so we have to overwrite the license and checksum here, too.

Otherwise the build system stops with an QA error.

[1]
https://git.openembedded.org/meta-openembedded/commit/?h=kirkstone&id=7d07ad57002a0af09ceb0fbe59b48ccd2ce4a740