### PR TITLE
Initial scarthgap compatibility

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,4 +9,4 @@ BBFILE_COLLECTIONS += "meta-everest"
 BBFILE_PATTERN_meta-everest = "^${LAYERDIR}/"
 
 LAYERDEPENDS_meta-everest = "core"
-LAYERSERIES_COMPAT_meta-everest = "kirkstone"
+LAYERSERIES_COMPAT_meta-everest = "kirkstone scarthgap"

--- a/recipes-backports/libwebsockets/libwebsockets_4.3.3.bb
+++ b/recipes-backports/libwebsockets/libwebsockets_4.3.3.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=382bfdf329e774859fd401eaf850d29b"
 DEPENDS = "zlib"
 
 S = "${WORKDIR}/git"
-SRCREV = "b0a749c8e7a8294b68581ce4feac0e55045eb00b"
+SRCREV = "4415e84c095857629863804e941b9e1c2e9347ef"
 SRC_URI = "git://github.com/warmcat/libwebsockets.git;protocol=https;branch=v4.3-stable"
 
 UPSTREAM_CHECK_URI = "https://github.com/warmcat/${BPN}/releases"

--- a/recipes-core/everest/everest-framework_0.13.0.bb
+++ b/recipes-core/everest/everest-framework_0.13.0.bb
@@ -36,10 +36,12 @@ DEPENDS = "\
 
 FILES:${PN} += "${libdir}/everest/* ${datadir}/everest/*"
 
+# we need to set PYTHON_INCLUDE_DIRS explicity, otherwise the host python is found
 EXTRA_OECMAKE += "\
     -DDISABLE_EDM=ON \
     -DNO_FETCH_CONTENT=ON \
     -DPYTHON_MODULE_EXTENSION=.so \
     -DPYBIND11_PYTHONLIBS_OVERWRITE=OFF \
     -DEVEREST_INSTALL_ADMIN_PANEL=OFF \
+    -DPYTHON_INCLUDE_DIRS="${STAGING_INCDIR}/${PYTHON_DIR}${PYTHON_ABI}" \
 "


### PR DESCRIPTION
Minimal changes to get scarthgap compatibility on the kirkstone branch. Since there are no major changes needed I just added this to the kirkstone branch to not have 2 almost identical branches that need to be kept up2date with each EVerest update