### PR TITLE
everest-core: make mbedtls configurable

### DIFF
--- a/recipes-core/everest/everest-core_2024.8.0.bb
+++ b/recipes-core/everest/everest-core_2024.8.0.bb
@@ -31,7 +31,6 @@ DEPENDS = " \
     libevent \
     libevse-security \
     libcbv2g \
-    openssl \
     curl \
     sqlitecpp \
 "
@@ -49,10 +48,14 @@ EXTRA_OECMAKE += " \
     -Deverest-core_INSTALL_EV_CLI_IN_PYTHON_VENV=OFF \
     -Deverest-core_USE_PYTHON_VENV=OFF \
     -DEV_SETUP_PYTHON_EXECUTABLE_USE_PYTHON_VENV=OFF \
-    -DUSING_MBED_TLS=OFF \
 "
 
 SYSTEMD_SERVICE:${PN} = "everest.service"
+
+PACKAGECONFIG ??= "openssl"
+
+PACKAGECONFIG[mbedtls] = "-DUSING_MBED_TLS=ON,-DUSING_MBED_TLS=OFF,mbedtls,,,openssl"
+PACKAGECONFIG[openssl] = "-DUSING_MBED_TLS=OFF,-DUSING_MBED_TLS=ON,openssl,,,mbedtls"
 
 do_install:append() {
     if ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'true', 'false', d)}; then


### PR DESCRIPTION
Since everest-core's/EvseV2G's mbedtls support still offers more features (notably logging of the TLS session key), make building with mbedtls a PACKAGECONFIG option.

Building with openssl remains the default.

Tested with an everest-core bbappend, both with and without `PACKAGECONFIG = "mbedtls"`. Works as expected.