### PR TITLE
everest-core: remove configuration option for mbedtls vs. openssl

### DIFF
--- a/recipes-core/everest/everest-core_2025.1.0.bb
+++ b/recipes-core/everest/everest-core_2025.1.0.bb
@@ -33,6 +33,7 @@ DEPENDS = " \
     libcbv2g \
     libiso15118 \
     libnfc-nci \
+    openssl \
     curl \
     sqlitecpp \
 "
@@ -53,11 +54,6 @@ EXTRA_OECMAKE += " \
 "
 
 SYSTEMD_SERVICE:${PN} = "everest.service"
-
-PACKAGECONFIG ??= "openssl"
-
-PACKAGECONFIG[mbedtls] = "-DUSING_MBED_TLS=ON,-DUSING_MBED_TLS=OFF,mbedtls,,,openssl"
-PACKAGECONFIG[openssl] = "-DUSING_MBED_TLS=OFF,-DUSING_MBED_TLS=ON,openssl,,,mbedtls"
 
 do_install:append() {
     if ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'true', 'false', d)}; then


### PR DESCRIPTION
OpenSSL is now (post merge of https://github.com/EVerest/everest-core/pull/1008) the only supported option.

This reverts commit 473f323cb562ccac8bf9e49654bfa69113bb833b, but drops the no longer supported build variable "-DUSING_MBED_TLS".