### PR TITLE
json-rpc-cxx: add header-only library recipe for RpcApi module

### DIFF
--- a/recipes-devtools/json-rpc-cxx/files/json-rpc-cxxConfig.cmake
+++ b/recipes-devtools/json-rpc-cxx/files/json-rpc-cxxConfig.cmake
@@ -1,0 +1,27 @@
+# Minimal CMake config for header-only json-rpc-cxx
+
+# Define INTERFACE library target
+add_library(json-rpc-cxx INTERFACE)
+
+# Compute the include and library directories relative to this file.
+
+get_filename_component(_JSONRPCCXX_CMAKEDIR "${CMAKE_CURRENT_LIST_DIR}/../" REALPATH)
+message(STATUS "Found json-rpc-cxx cmake config in ${CMAKE_CURRENT_LIST_DIR}, CMake dir is ${_JSONRPCCXX_CMAKEDIR}")
+
+# We will get deployed in ${INSTALL_PREFIX}/lib/cmake/json-rpc-cxx
+# and need to find ${INSTALL_PREFIX}/include.
+get_filename_component(_JSONRPCCXX_INCLUDEDIR
+    "${_JSONRPCCXX_CMAKEDIR}/../../include/"
+    ABSOLUTE
+)
+message(STATUS "Setting json-rpc-cxx include dir to ${_JSONRPCCXX_INCLUDEDIR}")
+# get_filename_component(_JSONRPCCXX_LIBDIR "${_JSONRPCCXX_CMAKEDIR}/../" ABSOLUTE)
+
+# Add include directory
+target_include_directories(json-rpc-cxx INTERFACE
+    ${_JSONRPCCXX_INCLUDEDIR}
+)
+
+# Ensure dependency on nlohmann_json is pulled in
+include(CMakeFindDependencyMacro)
+find_dependency(nlohmann_json)

--- a/recipes-devtools/json-rpc-cxx/json-rpc-cxx_0.3.2.bb
+++ b/recipes-devtools/json-rpc-cxx/json-rpc-cxx_0.3.2.bb
@@ -1,0 +1,25 @@
+SUMMARY = "JSON-RPC 2.0 framework for modern C++ (json-rpc-cxx)"
+HOMEPAGE = "https://github.com/jsonrpcx/json-rpc-cxx"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=23722aabb609187e801a18422ee3abb7"
+
+SRC_URI = "git://github.com/jsonrpcx/json-rpc-cxx.git;protocol=https;branch=master \
+           file://json-rpc-cxxConfig.cmake \
+          "
+SRCREV = "a0e195b575d62cb07016321ac9cd7e1b9e048fe5"
+
+inherit cmake
+
+S = "${WORKDIR}/git"
+
+RDEPENDS:${PN}-dev = "nlohmann-json-dev"
+
+EXTRA_OECMAKE = "-DCOMPILE_TESTS=OFF -DCOMPILE_EXAMPLES=OFF -DCODE_COVERAGE=OFF"
+
+do_install:append() {
+    install -d ${D}${libdir}/cmake/json-rpc-cxx
+    install -p -m 0644 ${WORKDIR}/json-rpc-cxxConfig.cmake \
+        ${D}${libdir}/cmake/json-rpc-cxx/
+}
+
+FILES:${PN}-dev += "${libdir}/cmake/json-rpc-cxx"


### PR DESCRIPTION
This library is required for the RpcApi module from everest-core PR https://github.com/EVerest/everest-core/pull/1324.

Also provide a minimal json-rpc-cxxConfig.cmake with INTERFACE target for the header-only library. This allows CMake to resolve and include the json-rpc-cxx target using find_package(json-rpc-cxx REQUIRED).