### PR TITLE
scarthgap update libwebsockets to 4.4.1

### DIFF
--- a/recipes-backports/libwebsockets/libwebsockets_4.4.1.bb
+++ b/recipes-backports/libwebsockets/libwebsockets_4.4.1.bb
@@ -1,0 +1,70 @@
+SUMMARY = "Canonical libwebsockets.org websocket library"
+HOMEPAGE = "https://libwebsockets.org/"
+LICENSE = "MIT & Zlib & BSD-3-Clause & Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=b5d391cc7929bcba238f9ba6805f7574"
+
+DEPENDS = "zlib"
+DEPENDS:append:class-native = " libcap-native"
+
+S = "${WORKDIR}/git"
+SRCREV = "adc128ca082a3c6fb9d4abbadefc09e3bc736724"
+SRC_URI = "git://github.com/warmcat/libwebsockets.git;protocol=https;branch=v4.4-stable"
+
+UPSTREAM_CHECK_URI = "https://github.com/warmcat/${BPN}/releases"
+UPSTREAM_CHECK_GITTAGREGEX = "v(?P<pver>\d+(\.\d+)+)"
+
+inherit cmake pkgconfig
+
+PACKAGECONFIG ?= "libuv libcap client server http2 ssl streamcompress ${@bb.utils.filter('DISTRO_FEATURES', 'ipv6', d)}"
+PACKAGECONFIG[client] = "-DLWS_WITHOUT_CLIENT=OFF,-DLWS_WITHOUT_CLIENT=ON,"
+PACKAGECONFIG[examples] = "-DLWS_WITH_MINIMAL_EXAMPLES=ON,-DLWS_WITH_MINIMAL_EXAMPLES=OFF,"
+PACKAGECONFIG[http2] = "-DLWS_WITH_HTTP2=ON,-DLWS_WITH_HTTP2=OFF,"
+PACKAGECONFIG[ipv6] = "-DLWS_IPV6=ON,-DLWS_IPV6=OFF,"
+PACKAGECONFIG[libcap] = "-DLWS_WITH_LIBCAP=ON,-DLWS_WITH_LIBCAP=OFF,libcap"
+PACKAGECONFIG[libevent] = "-DLWS_WITH_LIBEVENT=ON,-DLWS_WITH_LIBEVENT=OFF,libevent"
+PACKAGECONFIG[libev] = "-DLWS_WITH_LIBEV=ON,-DLWS_WITH_LIBEV=OFF,libev"
+PACKAGECONFIG[libuv] = "-DLWS_WITH_LIBUV=ON,-DLWS_WITH_LIBUV=OFF,libuv"
+PACKAGECONFIG[server] = "-DLWS_WITHOUT_SERVER=OFF,-DLWS_WITHOUT_SERVER=ON,"
+PACKAGECONFIG[ssl] = "-DLWS_WITH_SSL=ON,-DLWS_WITH_SSL=OFF,openssl"
+PACKAGECONFIG[static] = "-DLWS_WITH_STATIC=ON,-DLWS_WITH_STATIC=OFF -DLWS_LINK_TESTAPPS_DYNAMIC=ON,"
+PACKAGECONFIG[streamcompress] = "-DLWS_WITH_HTTP_STREAM_COMPRESSION=ON,-DLWS_WITH_HTTP_STREAM_COMPRESSION=OFF,zlib"
+PACKAGECONFIG[systemd] = "-DLWS_WITH_SDEVENT=ON,-DLWS_WITH_SDEVENT=OFF,systemd"
+
+python __anonymous() {
+  if bb.utils.contains('PACKAGECONFIG', 'systemd', True, False, d) and not bb.utils.contains('DISTRO_FEATURES', 'systemd', True, False, d):
+    bb.fatal("PACKAGECONFIG contains systemd but DISTRO_FEATURES doesn't")
+}
+
+EXTRA_OECMAKE += " \
+    -DLIB_SUFFIX=${@d.getVar('baselib').replace('lib', '')} \
+"
+
+do_install:append() {
+    sed -i -e 's|${STAGING_LIBDIR}/libcrypto.so|crypto|g' ${D}${libdir}/cmake/libwebsockets/LibwebsocketsTargets.cmake
+    sed -i -e 's|${STAGING_LIBDIR}/libssl.so|ssl|g' ${D}${libdir}/cmake/libwebsockets/LibwebsocketsTargets.cmake
+    sed -i -e 's|${STAGING_LIBDIR}/libuv.so|uv|g' ${D}${libdir}/cmake/libwebsockets/LibwebsocketsTargets.cmake
+    sed -i -e 's|${STAGING_INCDIR}||g' ${D}${libdir}/cmake/libwebsockets/LibwebsocketsTargets.cmake \
+                                       ${D}${libdir}/cmake/libwebsockets/libwebsockets-config.cmake
+    sed -i -e 's|${STAGING_LIBDIR}/||g' ${D}${libdir}/cmake/libwebsockets/LibwebsocketsTargets.cmake \
+                                        ${D}${libdir}/cmake/libwebsockets/libwebsockets-config.cmake
+}
+
+PACKAGES =+ "${PN}-testapps ${PN}-evlib-event ${PN}-evlib-uv ${PN}-evlib-ev ${PN}-evlib-sd"
+
+FILES:${PN}-testapps += "${datadir}/libwebsockets-test-server/* ${bindir}/libwebsockets-test-*"
+FILES:${PN}-evlib-event += "${libdir}/libwebsockets-evlib_event.so"
+FILES:${PN}-evlib-uv += "${libdir}/libwebsockets-evlib_uv.so"
+FILES:${PN}-evlib-ev += "${libdir}/libwebsockets-evlib_ev.so"
+FILES:${PN}-evlib-sd += "${libdir}/libwebsockets-evlib_sd.so"
+
+RDEPENDS:${PN} += " ${@bb.utils.contains('PACKAGECONFIG', 'libevent', '${PN}-evlib-event', '', d)}"
+RDEPENDS:${PN} += " ${@bb.utils.contains('PACKAGECONFIG', 'libuv', '${PN}-evlib-uv', '', d)}"
+RDEPENDS:${PN} += " ${@bb.utils.contains('PACKAGECONFIG', 'libev', '${PN}-evlib-ev', '', d)}"
+RDEPENDS:${PN} += " ${@bb.utils.contains('PACKAGECONFIG', 'systemd', '${PN}-evlib-sd', '', d)}"
+
+RDEPENDS:${PN}-dev += " ${@bb.utils.contains('PACKAGECONFIG', 'static', '${PN}-staticdev', '', d)}"
+
+# Avoid absolute paths to end up in the sysroot.
+SSTATE_SCAN_FILES += "*.cmake"
+
+BBCLASSEXTEND = "native"


### PR DESCRIPTION
* recipes-backports/libwebsockets: update to 4.4.1

Disable the now default-enabled examples, as they fail to compile anyway. Update the LICENSE md5.

* recipes-backports/libwebsockets: build with libcap and zlib

Building with zlib allows for compressed streams.
Building with libcap allows e.g. for binding to ports < 1024 as non-root. Add PACKAGECONFIG for each.

* recipes-backports/libwebsockets: fix libcap dependency and disable by default

libwebsockets is not compatible with libcap-ng, and requires libcap. Fix the dependency, and disable by default.

* recipes-backports/libwebsockets: change zlib packageconfig to stream compression

Enabling zlib by itself had no effect, as no features were using it. Allow configuring with stream compression explicitly instead. This pulls in the zlib configuration automatically.

Enable stream compression by default, again.

* recipes-backports/libwebsockets: enable libcap dependency by default

libcap is required by everest-framework anyway (for SubProcess).