### PR TITLE
kirkstone: Update sdbus-c++ dependency to 2.1.0

### DIFF
--- a/recipes-backports/sdbus-c++/sdbus-c++-libsystemd/0001-missing_type.h-add-comparison_fn_t.patch
+++ b/recipes-backports/sdbus-c++/sdbus-c++-libsystemd/0001-missing_type.h-add-comparison_fn_t.patch
@@ -1,0 +1,61 @@
+From 01195eb9f7d59139fb45df506ac6b3968c14a57f Mon Sep 17 00:00:00 2001
+From: Chen Qi <Qi.Chen@windriver.com>
+Date: Mon, 25 Feb 2019 13:55:12 +0800
+Subject: [PATCH 01/22] missing_type.h: add comparison_fn_t
+
+Make it work with musl where comparison_fn_t and is not provided.
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Alex Kiernan <alex.kiernan@gmail.com>
+[Rebased for v244]
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+[Rebased for v242]
+Signed-off-by: Andrej Valek <andrej.valek@siemens.com>
+[Rebased for v250, Drop __compare_fn_t]
+Signed-off-by: Jiaqing Zhao <jiaqing.zhao@linux.intel.com>
+---
+ src/basic/missing_type.h            | 4 ++++
+ src/basic/sort-util.h               | 1 +
+ src/libsystemd/sd-journal/catalog.c | 1 +
+ 3 files changed, 6 insertions(+)
+
+diff --git a/src/basic/missing_type.h b/src/basic/missing_type.h
+index f6233090a9..6c0456349d 100644
+--- a/src/basic/missing_type.h
++++ b/src/basic/missing_type.h
+@@ -10,3 +10,7 @@
+ #if !HAVE_CHAR16_T
+ #define char16_t uint16_t
+ #endif
++
++#ifndef __GLIBC__
++typedef int (*comparison_fn_t)(const void *, const void *);
++#endif
+diff --git a/src/basic/sort-util.h b/src/basic/sort-util.h
+index 9c818bd747..ef10c8be2c 100644
+--- a/src/basic/sort-util.h
++++ b/src/basic/sort-util.h
+@@ -4,6 +4,7 @@
+ #include <stdlib.h>
+ 
+ #include "macro.h"
++#include "missing_type.h"
+ 
+ /* This is the same as glibc's internal __compar_d_fn_t type. glibc exports a public comparison_fn_t, for the
+  * external type __compar_fn_t, but doesn't do anything similar for __compar_d_fn_t. Let's hence do that
+diff --git a/src/libsystemd/sd-journal/catalog.c b/src/libsystemd/sd-journal/catalog.c
+index ae91534198..7f67eea38b 100644
+--- a/src/libsystemd/sd-journal/catalog.c
++++ b/src/libsystemd/sd-journal/catalog.c
+@@ -28,6 +28,7 @@
+ #include "string-util.h"
+ #include "strv.h"
+ #include "tmpfile-util.h"
++#include "missing_type.h"
+ 
+ const char * const catalog_file_dirs[] = {
+         "/usr/local/lib/systemd/catalog/",
+-- 
+2.34.1
+

--- a/recipes-backports/sdbus-c++/sdbus-c++-libsystemd/0002-add-fallback-parse_printf_format-implementation.patch
+++ b/recipes-backports/sdbus-c++/sdbus-c++-libsystemd/0002-add-fallback-parse_printf_format-implementation.patch
@@ -1,0 +1,434 @@
+From 872b72739e62123867ce6c4f82aa37de24cc3f75 Mon Sep 17 00:00:00 2001
+From: Alexander Kanavin <alex.kanavin@gmail.com>
+Date: Sat, 22 May 2021 20:26:24 +0200
+Subject: [PATCH 02/22] add fallback parse_printf_format implementation
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Emil Renner Berthing <systemd@esmil.dk>
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+[rebased for systemd 243]
+Signed-off-by: Scott Murray <scott.murray@konsulko.com>
+---
+ meson.build                              |   1 +
+ src/basic/meson.build                    |   5 +
+ src/basic/parse-printf-format.c          | 273 +++++++++++++++++++++++
+ src/basic/parse-printf-format.h          |  57 +++++
+ src/basic/stdio-util.h                   |   2 +-
+ src/libsystemd/sd-journal/journal-send.c |   2 +-
+ 6 files changed, 338 insertions(+), 2 deletions(-)
+ create mode 100644 src/basic/parse-printf-format.c
+ create mode 100644 src/basic/parse-printf-format.h
+
+diff --git a/meson.build b/meson.build
+index 7419e2b0b0..01fd3ffc19 100644
+--- a/meson.build
++++ b/meson.build
+@@ -725,6 +725,7 @@ endif
+ foreach header : ['crypt.h',
+                   'linux/memfd.h',
+                   'linux/vm_sockets.h',
++                  'printf.h',
+                   'sys/auxv.h',
+                   'threads.h',
+                   'valgrind/memcheck.h',
+diff --git a/src/basic/meson.build b/src/basic/meson.build
+index d7450d8b44..c3e3daf4bd 100644
+--- a/src/basic/meson.build
++++ b/src/basic/meson.build
+@@ -183,6 +183,11 @@ endforeach
+ 
+ basic_sources += generated_gperf_headers
+ 
++if conf.get('HAVE_PRINTF_H') != 1
++        basic_sources += [files('parse-printf-format.c')]
++endif
++
++
+ ############################################################
+ 
+ arch_list = [
+diff --git a/src/basic/parse-printf-format.c b/src/basic/parse-printf-format.c
+new file mode 100644
+index 0000000000..49437e5445
+--- /dev/null
++++ b/src/basic/parse-printf-format.c
+@@ -0,0 +1,273 @@
++/*-*- Mode: C; c-basic-offset: 8; indent-tabs-mode: nil -*-*/
++
++/***
++  This file is part of systemd.
++
++  Copyright 2014 Emil Renner Berthing <systemd@esmil.dk>
++
++  With parts from the musl C library
++  Copyright 2005-2014 Rich Felker, et al.
++
++  systemd is free software; you can redistribute it and/or modify it
++  under the terms of the GNU Lesser General Public License as published by
++  the Free Software Foundation; either version 2.1 of the License, or
++  (at your option) any later version.
++
++  systemd is distributed in the hope that it will be useful, but
++  WITHOUT ANY WARRANTY; without even the implied warranty of
++  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
++  Lesser General Public License for more details.
++
++  You should have received a copy of the GNU Lesser General Public License
++  along with systemd; If not, see <http://www.gnu.org/licenses/>.
++***/
++
++#include <stddef.h>
++#include <string.h>
++
++#include "parse-printf-format.h"
++
++static const char *consume_nonarg(const char *fmt)
++{
++        do {
++                if (*fmt == '\0')
++                        return fmt;
++        } while (*fmt++ != '%');
++        return fmt;
++}
++
++static const char *consume_num(const char *fmt)
++{
++        for (;*fmt >= '0' && *fmt <= '9'; fmt++)
++                /* do nothing */;
++        return fmt;
++}
++
++static const char *consume_argn(const char *fmt, size_t *arg)
++{
++        const char *p = fmt;
++        size_t val = 0;
++
++        if (*p < '1' || *p > '9')
++                return fmt;
++        do {
++                val = 10*val + (*p++ - '0');
++        } while (*p >= '0' && *p <= '9');
++
++        if (*p != '$')
++                return fmt;
++        *arg = val;
++        return p+1;
++}
++
++static const char *consume_flags(const char *fmt)
++{
++        while (1) {
++                switch (*fmt) {
++                case '#':
++                case '0':
++                case '-':
++                case ' ':
++                case '+':
++                case '\'':
++                case 'I':
++                        fmt++;
++                        continue;
++                }
++                return fmt;
++        }
++}
++
++enum state {
++        BARE,
++        LPRE,
++        LLPRE,
++        HPRE,
++        HHPRE,
++        BIGLPRE,
++        ZTPRE,
++        JPRE,
++        STOP
++};
++
++enum type {
++        NONE,
++        PTR,
++        INT,
++        UINT,
++        ULLONG,
++        LONG,
++        ULONG,
++        SHORT,
++        USHORT,
++        CHAR,
++        UCHAR,
++        LLONG,
++        SIZET,
++        IMAX,
++        UMAX,
++        PDIFF,
++        UIPTR,
++        DBL,
++        LDBL,
++        MAXTYPE
++};
++
++static const short pa_types[MAXTYPE] = {
++        [NONE]   = PA_INT,
++        [PTR]    = PA_POINTER,
++        [INT]    = PA_INT,
++        [UINT]   = PA_INT,
++        [ULLONG] = PA_INT | PA_FLAG_LONG_LONG,
++        [LONG]   = PA_INT | PA_FLAG_LONG,
++        [ULONG]  = PA_INT | PA_FLAG_LONG,
++        [SHORT]  = PA_INT | PA_FLAG_SHORT,
++        [USHORT] = PA_INT | PA_FLAG_SHORT,
++        [CHAR]   = PA_CHAR,
++        [UCHAR]  = PA_CHAR,
++        [LLONG]  = PA_INT | PA_FLAG_LONG_LONG,
++        [SIZET]  = PA_INT | PA_FLAG_LONG,
++        [IMAX]   = PA_INT | PA_FLAG_LONG_LONG,
++        [UMAX]   = PA_INT | PA_FLAG_LONG_LONG,
++        [PDIFF]  = PA_INT | PA_FLAG_LONG_LONG,
++        [UIPTR]  = PA_INT | PA_FLAG_LONG,
++        [DBL]    = PA_DOUBLE,
++        [LDBL]   = PA_DOUBLE | PA_FLAG_LONG_DOUBLE
++};
++
++#define S(x) [(x)-'A']
++#define E(x) (STOP + (x))
++
++static const unsigned char states[]['z'-'A'+1] = {
++        { /* 0: bare types */
++                S('d') = E(INT), S('i') = E(INT),
++                S('o') = E(UINT),S('u') = E(UINT),S('x') = E(UINT), S('X') = E(UINT),
++                S('e') = E(DBL), S('f') = E(DBL), S('g') = E(DBL),  S('a') = E(DBL),
++                S('E') = E(DBL), S('F') = E(DBL), S('G') = E(DBL),  S('A') = E(DBL),
++                S('c') = E(CHAR),S('C') = E(INT),
++                S('s') = E(PTR), S('S') = E(PTR), S('p') = E(UIPTR),S('n') = E(PTR),
++                S('m') = E(NONE),
++                S('l') = LPRE,   S('h') = HPRE, S('L') = BIGLPRE,
++                S('z') = ZTPRE,  S('j') = JPRE, S('t') = ZTPRE
++        }, { /* 1: l-prefixed */
++                S('d') = E(LONG), S('i') = E(LONG),
++                S('o') = E(ULONG),S('u') = E(ULONG),S('x') = E(ULONG),S('X') = E(ULONG),
++                S('e') = E(DBL),  S('f') = E(DBL),  S('g') = E(DBL),  S('a') = E(DBL),
++                S('E') = E(DBL),  S('F') = E(DBL),  S('G') = E(DBL),  S('A') = E(DBL),
++                S('c') = E(INT),  S('s') = E(PTR),  S('n') = E(PTR),
++                S('l') = LLPRE
++        }, { /* 2: ll-prefixed */
++                S('d') = E(LLONG), S('i') = E(LLONG),
++                S('o') = E(ULLONG),S('u') = E(ULLONG),
++                S('x') = E(ULLONG),S('X') = E(ULLONG),
++                S('n') = E(PTR)
++        }, { /* 3: h-prefixed */
++                S('d') = E(SHORT), S('i') = E(SHORT),
++                S('o') = E(USHORT),S('u') = E(USHORT),
++                S('x') = E(USHORT),S('X') = E(USHORT),
++                S('n') = E(PTR),
++                S('h') = HHPRE
++        }, { /* 4: hh-prefixed */
++                S('d') = E(CHAR), S('i') = E(CHAR),
++                S('o') = E(UCHAR),S('u') = E(UCHAR),
++                S('x') = E(UCHAR),S('X') = E(UCHAR),
++                S('n') = E(PTR)
++        }, { /* 5: L-prefixed */
++                S('e') = E(LDBL),S('f') = E(LDBL),S('g') = E(LDBL), S('a') = E(LDBL),
++                S('E') = E(LDBL),S('F') = E(LDBL),S('G') = E(LDBL), S('A') = E(LDBL),
++                S('n') = E(PTR)
++        }, { /* 6: z- or t-prefixed (assumed to be same size) */
++                S('d') = E(PDIFF),S('i') = E(PDIFF),
++                S('o') = E(SIZET),S('u') = E(SIZET),
++                S('x') = E(SIZET),S('X') = E(SIZET),
++                S('n') = E(PTR)
++        }, { /* 7: j-prefixed */
++                S('d') = E(IMAX), S('i') = E(IMAX),
++                S('o') = E(UMAX), S('u') = E(UMAX),
++                S('x') = E(UMAX), S('X') = E(UMAX),
++                S('n') = E(PTR)
++        }
++};
++
++size_t parse_printf_format(const char *fmt, size_t n, int *types)
++{
++        size_t i = 0;
++        size_t last = 0;
++
++        memset(types, 0, n);
++
++        while (1) {
++                size_t arg;
++                unsigned int state;
++
++                fmt = consume_nonarg(fmt);
++                if (*fmt == '\0')
++                        break;
++                if (*fmt == '%') {
++                        fmt++;
++                        continue;
++                }
++                arg = 0;
++                fmt = consume_argn(fmt, &arg);
++                /* flags */
++                fmt = consume_flags(fmt);
++                /* width */
++                if (*fmt == '*') {
++                        size_t warg = 0;
++                        fmt = consume_argn(fmt+1, &warg);
++                        if (warg == 0)
++                                warg = ++i;
++                        if (warg > last)
++                                last = warg;
++                        if (warg <= n && types[warg-1] == NONE)
++                                types[warg-1] = INT;
++                } else
++                        fmt = consume_num(fmt);
++                /* precision */
++                if (*fmt == '.') {
++                        fmt++;
++                        if (*fmt == '*') {
++                                size_t parg = 0;
++                                fmt = consume_argn(fmt+1, &parg);
++                                if (parg == 0)
++                                        parg = ++i;
++                                if (parg > last)
++                                        last = parg;
++                                if (parg <= n && types[parg-1] == NONE)
++                                        types[parg-1] = INT;
++                        } else {
++                                if (*fmt == '-')
++                                        fmt++;
++                                fmt = consume_num(fmt);
++                        }
++                }
++                /* length modifier and conversion specifier */
++                state = BARE;
++                do {
++                        unsigned char c = *fmt++;
++
++                        if (c < 'A' || c > 'z')
++                                continue;
++                        state = states[state]S(c);
++                        if (state == 0)
++                                continue;
++                } while (state < STOP);
++
++                if (state == E(NONE))
++                        continue;
++
++                if (arg == 0)
++                        arg = ++i;
++                if (arg > last)
++                        last = arg;
++                if (arg <= n)
++                        types[arg-1] = state - STOP;
++        }
++
++        if (last > n)
++                last = n;
++        for (i = 0; i < last; i++)
++                types[i] = pa_types[types[i]];
++
++        return last;
++}
+diff --git a/src/basic/parse-printf-format.h b/src/basic/parse-printf-format.h
+new file mode 100644
+index 0000000000..47be7522d7
+--- /dev/null
++++ b/src/basic/parse-printf-format.h
+@@ -0,0 +1,57 @@
++/*-*- Mode: C; c-basic-offset: 8; indent-tabs-mode: nil -*-*/
++
++/***
++  This file is part of systemd.
++
++  Copyright 2014 Emil Renner Berthing <systemd@esmil.dk>
++
++  With parts from the GNU C Library
++  Copyright 1991-2014 Free Software Foundation, Inc.
++
++  systemd is free software; you can redistribute it and/or modify it
++  under the terms of the GNU Lesser General Public License as published by
++  the Free Software Foundation; either version 2.1 of the License, or
++  (at your option) any later version.
++
++  systemd is distributed in the hope that it will be useful, but
++  WITHOUT ANY WARRANTY; without even the implied warranty of
++  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
++  Lesser General Public License for more details.
++
++  You should have received a copy of the GNU Lesser General Public License
++  along with systemd; If not, see <http://www.gnu.org/licenses/>.
++***/
++
++#pragma once
++
++#include "config.h"
++
++#if HAVE_PRINTF_H
++#include <printf.h>
++#else
++
++#include <stddef.h>
++
++enum {				/* C type: */
++  PA_INT,			/* int */
++  PA_CHAR,			/* int, cast to char */
++  PA_WCHAR,			/* wide char */
++  PA_STRING,			/* const char *, a '\0'-terminated string */
++  PA_WSTRING,			/* const wchar_t *, wide character string */
++  PA_POINTER,			/* void * */
++  PA_FLOAT,			/* float */
++  PA_DOUBLE,			/* double */
++  PA_LAST
++};
++
++/* Flag bits that can be set in a type returned by `parse_printf_format'.  */
++#define	PA_FLAG_MASK		0xff00
++#define	PA_FLAG_LONG_LONG	(1 << 8)
++#define	PA_FLAG_LONG_DOUBLE	PA_FLAG_LONG_LONG
++#define	PA_FLAG_LONG		(1 << 9)
++#define	PA_FLAG_SHORT		(1 << 10)
++#define	PA_FLAG_PTR		(1 << 11)
++
++size_t parse_printf_format(const char *fmt, size_t n, int *types);
++
++#endif /* HAVE_PRINTF_H */
+diff --git a/src/basic/stdio-util.h b/src/basic/stdio-util.h
+index 4e93ac90c9..f9deb6f662 100644
+--- a/src/basic/stdio-util.h
++++ b/src/basic/stdio-util.h
+@@ -1,12 +1,12 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+ #pragma once
+ 
+-#include <printf.h>
+ #include <stdarg.h>
+ #include <stdio.h>
+ #include <sys/types.h>
+ 
+ #include "macro.h"
++#include "parse-printf-format.h"
+ 
+ _printf_(3, 4)
+ static inline char *snprintf_ok(char *buf, size_t len, const char *format, ...) {
+diff --git a/src/libsystemd/sd-journal/journal-send.c b/src/libsystemd/sd-journal/journal-send.c
+index be23b2fe75..69a2eb6404 100644
+--- a/src/libsystemd/sd-journal/journal-send.c
++++ b/src/libsystemd/sd-journal/journal-send.c
+@@ -2,7 +2,6 @@
+ 
+ #include <errno.h>
+ #include <fcntl.h>
+-#include <printf.h>
+ #include <stddef.h>
+ #include <sys/un.h>
+ #include <unistd.h>
+@@ -28,6 +27,7 @@
+ #include "stdio-util.h"
+ #include "string-util.h"
+ #include "tmpfile-util.h"
++#include "parse-printf-format.h"
+ 
+ #define SNDBUF_SIZE (8*1024*1024)
+ 
+-- 
+2.34.1
+

--- a/recipes-backports/sdbus-c++/sdbus-c++-libsystemd/0002-binfmt-Don-t-install-dependency-links-at-install-tim.patch
+++ b/recipes-backports/sdbus-c++/sdbus-c++-libsystemd/0002-binfmt-Don-t-install-dependency-links-at-install-tim.patch
@@ -1,0 +1,79 @@
+From 29a58009a172e369ad7166e16dab2f4945c6b0d2 Mon Sep 17 00:00:00 2001
+From: Chen Qi <Qi.Chen@windriver.com>
+Date: Thu, 21 Feb 2019 16:23:24 +0800
+Subject: [PATCH 1/2] binfmt: Don't install dependency links at install time
+ for the binfmt services
+
+use [Install] blocks so that they get created when the service is enabled
+like a traditional service.
+
+The [Install] blocks were rejected upstream as they don't have a way to
+"enable" it on install without static symlinks which can't be disabled,
+only masked. We however can do that in a postinst.
+
+Upstream-Status: Denied
+
+Signed-off-by: Ross Burton <ross.burton@intel.com>
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+[rebased for systemd 243]
+Signed-off-by: Scott Murray <scott.murray@konsulko.com>
+---
+ units/meson.build                       | 2 --
+ units/proc-sys-fs-binfmt_misc.automount | 3 +++
+ units/systemd-binfmt.service.in         | 4 ++++
+ 3 files changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/units/meson.build b/units/meson.build
+index e7bfb7f838..1d5ec4b178 100644
+--- a/units/meson.build
++++ b/units/meson.build
+@@ -154,7 +154,6 @@ units = [
+         {
+           'file' : 'proc-sys-fs-binfmt_misc.automount',
+           'conditions' : ['ENABLE_BINFMT'],
+-          'symlinks' : ['sysinit.target.wants/'],
+         },
+         {
+           'file' : 'proc-sys-fs-binfmt_misc.mount',
+@@ -251,7 +250,6 @@ units = [
+         {
+           'file' : 'systemd-binfmt.service.in',
+           'conditions' : ['ENABLE_BINFMT'],
+-          'symlinks' : ['sysinit.target.wants/'],
+         },
+         {
+           'file' : 'systemd-bless-boot.service.in',
+diff --git a/units/proc-sys-fs-binfmt_misc.automount b/units/proc-sys-fs-binfmt_misc.automount
+index 5d212015a5..6c2900ca77 100644
+--- a/units/proc-sys-fs-binfmt_misc.automount
++++ b/units/proc-sys-fs-binfmt_misc.automount
+@@ -22,3 +22,6 @@ Before=shutdown.target
+ 
+ [Automount]
+ Where=/proc/sys/fs/binfmt_misc
++
++[Install]
++WantedBy=sysinit.target
+diff --git a/units/systemd-binfmt.service.in b/units/systemd-binfmt.service.in
+index 6861c76674..531e9fbd90 100644
+--- a/units/systemd-binfmt.service.in
++++ b/units/systemd-binfmt.service.in
+@@ -14,6 +14,7 @@ Documentation=https://docs.kernel.org/admin-guide/binfmt-misc.html
+ Documentation=https://www.freedesktop.org/wiki/Software/systemd/APIFileSystems
+ DefaultDependencies=no
+ Conflicts=shutdown.target
++Wants=proc-sys-fs-binfmt_misc.automount
+ After=proc-sys-fs-binfmt_misc.automount
+ After=proc-sys-fs-binfmt_misc.mount
+ After=local-fs.target
+@@ -31,3 +32,6 @@ RemainAfterExit=yes
+ ExecStart={{LIBEXECDIR}}/systemd-binfmt
+ ExecStop={{LIBEXECDIR}}/systemd-binfmt --unregister
+ TimeoutSec=90s
++
++[Install]
++WantedBy=sysinit.target
+-- 
+2.34.1
+

--- a/recipes-backports/sdbus-c++/sdbus-c++-libsystemd/0003-src-basic-missing.h-check-for-missing-strndupa.patch
+++ b/recipes-backports/sdbus-c++/sdbus-c++-libsystemd/0003-src-basic-missing.h-check-for-missing-strndupa.patch
@@ -1,0 +1,699 @@
+From 87f1d38f40c5fe9cadf2b2de442473e4e5605788 Mon Sep 17 00:00:00 2001
+From: Chen Qi <Qi.Chen@windriver.com>
+Date: Mon, 25 Feb 2019 14:18:21 +0800
+Subject: [PATCH 03/22] src/basic/missing.h: check for missing strndupa
+
+include missing.h  for definition of strndupa
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+[Rebased for v242]
+Signed-off-by: Andrej Valek <andrej.valek@siemens.com>
+[rebased for systemd 243]
+Signed-off-by: Scott Murray <scott.murray@konsulko.com>
+Signed-off-by: Alex Kiernan <alex.kiernan@gmail.com>
+[rebased for systemd 244]
+[Rebased for v247]
+Signed-off-by: Luca Boccassi <luca.boccassi@microsoft.com>
+[Rebased for v254]
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+[Rebased for v255.1]
+---
+ meson.build                                |  1 +
+ src/backlight/backlight.c                  |  1 +
+ src/basic/cgroup-util.c                    |  1 +
+ src/basic/env-util.c                       |  1 +
+ src/basic/log.c                            |  1 +
+ src/basic/missing_stdlib.h                 | 12 ++++++++++++
+ src/basic/mkdir.c                          |  1 +
+ src/basic/mountpoint-util.c                |  1 +
+ src/basic/parse-util.c                     |  1 +
+ src/basic/path-lookup.c                    |  1 +
+ src/basic/percent-util.c                   |  1 +
+ src/basic/proc-cmdline.c                   |  1 +
+ src/basic/procfs-util.c                    |  1 +
+ src/basic/time-util.c                      |  1 +
+ src/boot/bless-boot.c                      |  1 +
+ src/core/dbus-cgroup.c                     |  1 +
+ src/core/dbus-execute.c                    |  1 +
+ src/core/dbus-util.c                       |  1 +
+ src/core/execute.c                         |  1 +
+ src/core/kmod-setup.c                      |  1 +
+ src/core/service.c                         |  1 +
+ src/coredump/coredump-vacuum.c             |  1 +
+ src/fstab-generator/fstab-generator.c      |  1 +
+ src/journal-remote/journal-remote-main.c   |  1 +
+ src/journal/journalctl.c                   |  1 +
+ src/libsystemd/sd-bus/bus-message.c        |  1 +
+ src/libsystemd/sd-bus/bus-objects.c        |  1 +
+ src/libsystemd/sd-bus/bus-socket.c         |  1 +
+ src/libsystemd/sd-bus/sd-bus.c             |  1 +
+ src/libsystemd/sd-bus/test-bus-benchmark.c |  1 +
+ src/libsystemd/sd-journal/sd-journal.c     |  1 +
+ src/login/pam_systemd.c                    |  1 +
+ src/network/generator/network-generator.c  |  1 +
+ src/nspawn/nspawn-settings.c               |  1 +
+ src/nss-mymachines/nss-mymachines.c        |  1 +
+ src/portable/portable.c                    |  1 +
+ src/resolve/resolvectl.c                   |  1 +
+ src/shared/bus-get-properties.c            |  1 +
+ src/shared/bus-unit-procs.c                |  1 +
+ src/shared/bus-unit-util.c                 |  1 +
+ src/shared/bus-util.c                      |  1 +
+ src/shared/dns-domain.c                    |  1 +
+ src/shared/journal-importer.c              |  1 +
+ src/shared/logs-show.c                     |  1 +
+ src/shared/pager.c                         |  1 +
+ src/socket-proxy/socket-proxyd.c           |  1 +
+ src/test/test-hexdecoct.c                  |  1 +
+ src/udev/udev-builtin-net_id.c             |  1 +
+ src/udev/udev-builtin-path_id.c            |  1 +
+ src/udev/udev-event.c                      |  1 +
+ src/udev/udev-rules.c                      |  1 +
+ 51 files changed, 62 insertions(+)
+
+diff --git a/meson.build b/meson.build
+index 01fd3ffc19..61a872b753 100644
+--- a/meson.build
++++ b/meson.build
+@@ -567,6 +567,7 @@ foreach ident : ['secure_getenv', '__secure_getenv']
+ endforeach
+ 
+ foreach ident : [
++        ['strndupa' ,         '''#include <string.h>'''],
+         ['memfd_create',      '''#include <sys/mman.h>'''],
+         ['gettid',            '''#include <sys/types.h>
+                                  #include <unistd.h>'''],
+diff --git a/src/backlight/backlight.c b/src/backlight/backlight.c
+index 5ac9f904a9..99d5122dd7 100644
+--- a/src/backlight/backlight.c
++++ b/src/backlight/backlight.c
+@@ -20,6 +20,7 @@
+ #include "string-util.h"
+ #include "strv.h"
+ #include "terminal-util.h"
++#include "missing_stdlib.h"
+ 
+ #define PCI_CLASS_GRAPHICS_CARD 0x30000
+ 
+diff --git a/src/basic/cgroup-util.c b/src/basic/cgroup-util.c
+index 18b16ecc0e..d2be79622f 100644
+--- a/src/basic/cgroup-util.c
++++ b/src/basic/cgroup-util.c
+@@ -38,6 +38,7 @@
+ #include "unit-name.h"
+ #include "user-util.h"
+ #include "xattr-util.h"
++#include "missing_stdlib.h"
+ 
+ static int cg_enumerate_items(const char *controller, const char *path, FILE **ret, const char *item) {
+         _cleanup_free_ char *fs = NULL;
+diff --git a/src/basic/env-util.c b/src/basic/env-util.c
+index d3bf73385f..16b17358ca 100644
+--- a/src/basic/env-util.c
++++ b/src/basic/env-util.c
+@@ -19,6 +19,7 @@
+ #include "string-util.h"
+ #include "strv.h"
+ #include "utf8.h"
++#include "missing_stdlib.h"
+ 
+ /* We follow bash for the character set. Different shells have different rules. */
+ #define VALID_BASH_ENV_NAME_CHARS               \
+diff --git a/src/basic/log.c b/src/basic/log.c
+index 1470611a75..9924ec2b9a 100644
+--- a/src/basic/log.c
++++ b/src/basic/log.c
+@@ -40,6 +40,7 @@
+ #include "terminal-util.h"
+ #include "time-util.h"
+ #include "utf8.h"
++#include "missing_stdlib.h"
+ 
+ #define SNDBUF_SIZE (8*1024*1024)
+ #define IOVEC_MAX 256U
+diff --git a/src/basic/missing_stdlib.h b/src/basic/missing_stdlib.h
+index 8c76f93eb2..9068bfb4f0 100644
+--- a/src/basic/missing_stdlib.h
++++ b/src/basic/missing_stdlib.h
+@@ -11,3 +11,15 @@
+ #    error "neither secure_getenv nor __secure_getenv are available"
+ #  endif
+ #endif
++
++/* string.h */
++#if ! HAVE_STRNDUPA
++#define strndupa(s, n) \
++  ({ \
++    const char *__old = (s); \
++    size_t __len = strnlen(__old, (n)); \
++    char *__new = (char *)alloca(__len + 1); \
++    __new[__len] = '\0'; \
++    (char *)memcpy(__new, __old, __len); \
++  })
++#endif
+diff --git a/src/basic/mkdir.c b/src/basic/mkdir.c
+index c770e5ed32..1fd8816cd0 100644
+--- a/src/basic/mkdir.c
++++ b/src/basic/mkdir.c
+@@ -16,6 +16,7 @@
+ #include "stat-util.h"
+ #include "stdio-util.h"
+ #include "user-util.h"
++#include "missing_stdlib.h"
+ 
+ int mkdirat_safe_internal(
+                 int dir_fd,
+diff --git a/src/basic/mountpoint-util.c b/src/basic/mountpoint-util.c
+index bf67f7e01a..409f8d8a73 100644
+--- a/src/basic/mountpoint-util.c
++++ b/src/basic/mountpoint-util.c
+@@ -18,6 +18,7 @@
+ #include "missing_stat.h"
+ #include "missing_syscall.h"
+ #include "mkdir.h"
++#include "missing_stdlib.h"
+ #include "mountpoint-util.h"
+ #include "nulstr-util.h"
+ #include "parse-util.h"
+diff --git a/src/basic/parse-util.c b/src/basic/parse-util.c
+index 0430e33e40..f3728de026 100644
+--- a/src/basic/parse-util.c
++++ b/src/basic/parse-util.c
+@@ -18,6 +18,7 @@
+ #include "stat-util.h"
+ #include "string-util.h"
+ #include "strv.h"
++#include "missing_stdlib.h"
+ 
+ int parse_boolean(const char *v) {
+         if (!v)
+diff --git a/src/basic/path-lookup.c b/src/basic/path-lookup.c
+index 4e3d59fc56..726e240df0 100644
+--- a/src/basic/path-lookup.c
++++ b/src/basic/path-lookup.c
+@@ -16,6 +16,7 @@
+ #include "strv.h"
+ #include "tmpfile-util.h"
+ #include "user-util.h"
++#include "missing_stdlib.h"
+ 
+ int xdg_user_runtime_dir(char **ret, const char *suffix) {
+         const char *e;
+diff --git a/src/basic/percent-util.c b/src/basic/percent-util.c
+index cab9d0eaea..5f6ca258e9 100644
+--- a/src/basic/percent-util.c
++++ b/src/basic/percent-util.c
+@@ -3,6 +3,7 @@
+ #include "percent-util.h"
+ #include "string-util.h"
+ #include "parse-util.h"
++#include "missing_stdlib.h"
+ 
+ static int parse_parts_value_whole(const char *p, const char *symbol) {
+         const char *pc, *n;
+diff --git a/src/basic/proc-cmdline.c b/src/basic/proc-cmdline.c
+index 522d8de1f4..7c129dc0fc 100644
+--- a/src/basic/proc-cmdline.c
++++ b/src/basic/proc-cmdline.c
+@@ -16,6 +16,7 @@
+ #include "string-util.h"
+ #include "strv.h"
+ #include "virt.h"
++#include "missing_stdlib.h"
+ 
+ int proc_cmdline_filter_pid1_args(char **argv, char ***ret) {
+         enum {
+diff --git a/src/basic/procfs-util.c b/src/basic/procfs-util.c
+index d7cfcd9105..6cb0ddf575 100644
+--- a/src/basic/procfs-util.c
++++ b/src/basic/procfs-util.c
+@@ -12,6 +12,7 @@
+ #include "procfs-util.h"
+ #include "stdio-util.h"
+ #include "string-util.h"
++#include "missing_stdlib.h"
+ 
+ int procfs_get_pid_max(uint64_t *ret) {
+         _cleanup_free_ char *value = NULL;
+diff --git a/src/basic/time-util.c b/src/basic/time-util.c
+index f9014dc560..1d7840a5b5 100644
+--- a/src/basic/time-util.c
++++ b/src/basic/time-util.c
+@@ -27,6 +27,7 @@
+ #include "string-util.h"
+ #include "strv.h"
+ #include "time-util.h"
++#include "missing_stdlib.h"
+ 
+ static clockid_t map_clock_id(clockid_t c) {
+ 
+diff --git a/src/boot/bless-boot.c b/src/boot/bless-boot.c
+index 0c0b4f23c7..68fe5ca509 100644
+--- a/src/boot/bless-boot.c
++++ b/src/boot/bless-boot.c
+@@ -22,6 +22,7 @@
+ #include "terminal-util.h"
+ #include "verbs.h"
+ #include "virt.h"
++#include "missing_stdlib.h"
+ 
+ static char **arg_path = NULL;
+ 
+diff --git a/src/core/dbus-cgroup.c b/src/core/dbus-cgroup.c
+index 4237e694c0..05f9d9d9a9 100644
+--- a/src/core/dbus-cgroup.c
++++ b/src/core/dbus-cgroup.c
+@@ -25,6 +25,7 @@
+ #include "parse-util.h"
+ #include "path-util.h"
+ #include "percent-util.h"
++#include "missing_stdlib.h"
+ #include "socket-util.h"
+ 
+ BUS_DEFINE_PROPERTY_GET(bus_property_get_tasks_max, "t", CGroupTasksMax, cgroup_tasks_max_resolve);
+diff --git a/src/core/dbus-execute.c b/src/core/dbus-execute.c
+index 4daa1cefd3..2c77901471 100644
+--- a/src/core/dbus-execute.c
++++ b/src/core/dbus-execute.c
+@@ -42,6 +42,7 @@
+ #include "unit-printf.h"
+ #include "user-util.h"
+ #include "utf8.h"
++#include "missing_stdlib.h"
+ 
+ BUS_DEFINE_PROPERTY_GET_ENUM(bus_property_get_exec_output, exec_output, ExecOutput);
+ static BUS_DEFINE_PROPERTY_GET_ENUM(property_get_exec_input, exec_input, ExecInput);
+diff --git a/src/core/dbus-util.c b/src/core/dbus-util.c
+index d680a64268..e59f48103e 100644
+--- a/src/core/dbus-util.c
++++ b/src/core/dbus-util.c
+@@ -9,6 +9,7 @@
+ #include "unit-printf.h"
+ #include "user-util.h"
+ #include "unit.h"
++#include "missing_stdlib.h"
+ 
+ int bus_property_get_triggered_unit(
+                 sd_bus *bus,
+diff --git a/src/core/execute.c b/src/core/execute.c
+index ef0bf88687..bd3da0c401 100644
+--- a/src/core/execute.c
++++ b/src/core/execute.c
+@@ -72,6 +72,7 @@
+ #include "unit-serialize.h"
+ #include "user-util.h"
+ #include "utmp-wtmp.h"
++#include "missing_stdlib.h"
+ 
+ static bool is_terminal_input(ExecInput i) {
+         return IN_SET(i,
+diff --git a/src/core/kmod-setup.c b/src/core/kmod-setup.c
+index b8e3f7aadd..8ce8ca68d8 100644
+--- a/src/core/kmod-setup.c
++++ b/src/core/kmod-setup.c
+@@ -13,6 +13,7 @@
+ #include "string-util.h"
+ #include "strv.h"
+ #include "virt.h"
++#include "missing_stdlib.h"
+ 
+ #if HAVE_KMOD
+ #include "module-util.h"
+diff --git a/src/core/service.c b/src/core/service.c
+index b9eb40c555..268fe7573b 100644
+--- a/src/core/service.c
++++ b/src/core/service.c
+@@ -45,6 +45,7 @@
+ #include "unit-name.h"
+ #include "unit.h"
+ #include "utf8.h"
++#include "missing_stdlib.h"
+ 
+ #define service_spawn(...) service_spawn_internal(__func__, __VA_ARGS__)
+ 
+diff --git a/src/coredump/coredump-vacuum.c b/src/coredump/coredump-vacuum.c
+index 7e0c98cb7d..978a7f5874 100644
+--- a/src/coredump/coredump-vacuum.c
++++ b/src/coredump/coredump-vacuum.c
+@@ -17,6 +17,7 @@
+ #include "string-util.h"
+ #include "time-util.h"
+ #include "user-util.h"
++#include "missing_stdlib.h"
+ 
+ #define DEFAULT_MAX_USE_LOWER (uint64_t) (1ULL*1024ULL*1024ULL)           /* 1 MiB */
+ #define DEFAULT_MAX_USE_UPPER (uint64_t) (4ULL*1024ULL*1024ULL*1024ULL)   /* 4 GiB */
+diff --git a/src/fstab-generator/fstab-generator.c b/src/fstab-generator/fstab-generator.c
+index 016f3baa7f..b1def81313 100644
+--- a/src/fstab-generator/fstab-generator.c
++++ b/src/fstab-generator/fstab-generator.c
+@@ -37,6 +37,7 @@
+ #include "unit-name.h"
+ #include "virt.h"
+ #include "volatile-util.h"
++#include "missing_stdlib.h"
+ 
+ typedef enum MountPointFlags {
+         MOUNT_NOAUTO    = 1 << 0,
+diff --git a/src/journal-remote/journal-remote-main.c b/src/journal-remote/journal-remote-main.c
+index da0f20d3ce..f22ce41908 100644
+--- a/src/journal-remote/journal-remote-main.c
++++ b/src/journal-remote/journal-remote-main.c
+@@ -27,6 +27,7 @@
+ #include "stat-util.h"
+ #include "string-table.h"
+ #include "strv.h"
++#include "missing_stdlib.h"
+ 
+ #define PRIV_KEY_FILE CERTIFICATE_ROOT "/private/journal-remote.pem"
+ #define CERT_FILE     CERTIFICATE_ROOT "/certs/journal-remote.pem"
+diff --git a/src/journal/journalctl.c b/src/journal/journalctl.c
+index 7f3dcd56a4..41b7cbaaf1 100644
+--- a/src/journal/journalctl.c
++++ b/src/journal/journalctl.c
+@@ -77,6 +77,7 @@
+ #include "unit-name.h"
+ #include "user-util.h"
+ #include "varlink.h"
++#include "missing_stdlib.h"
+ 
+ #define DEFAULT_FSS_INTERVAL_USEC (15*USEC_PER_MINUTE)
+ #define PROCESS_INOTIFY_INTERVAL 1024   /* Every 1,024 messages processed */
+diff --git a/src/libsystemd/sd-bus/bus-message.c b/src/libsystemd/sd-bus/bus-message.c
+index ff0228081f..9066fcb133 100644
+--- a/src/libsystemd/sd-bus/bus-message.c
++++ b/src/libsystemd/sd-bus/bus-message.c
+@@ -19,6 +19,7 @@
+ #include "strv.h"
+ #include "time-util.h"
+ #include "utf8.h"
++#include "missing_stdlib.h"
+ 
+ static int message_append_basic(sd_bus_message *m, char type, const void *p, const void **stored);
+ static int message_parse_fields(sd_bus_message *m);
+diff --git a/src/libsystemd/sd-bus/bus-objects.c b/src/libsystemd/sd-bus/bus-objects.c
+index c25c40ff37..57a5da704f 100644
+--- a/src/libsystemd/sd-bus/bus-objects.c
++++ b/src/libsystemd/sd-bus/bus-objects.c
+@@ -11,6 +11,7 @@
+ #include "missing_capability.h"
+ #include "string-util.h"
+ #include "strv.h"
++#include "missing_stdlib.h"
+ 
+ static int node_vtable_get_userdata(
+                 sd_bus *bus,
+diff --git a/src/libsystemd/sd-bus/bus-socket.c b/src/libsystemd/sd-bus/bus-socket.c
+index 3c59d0d615..746922d46f 100644
+--- a/src/libsystemd/sd-bus/bus-socket.c
++++ b/src/libsystemd/sd-bus/bus-socket.c
+@@ -29,6 +29,7 @@
+ #include "string-util.h"
+ #include "user-util.h"
+ #include "utf8.h"
++#include "missing_stdlib.h"
+ 
+ #define SNDBUF_SIZE (8*1024*1024)
+ 
+diff --git a/src/libsystemd/sd-bus/sd-bus.c b/src/libsystemd/sd-bus/sd-bus.c
+index 4a0259f8bb..aaa90d2223 100644
+--- a/src/libsystemd/sd-bus/sd-bus.c
++++ b/src/libsystemd/sd-bus/sd-bus.c
+@@ -46,6 +46,7 @@
+ #include "string-util.h"
+ #include "strv.h"
+ #include "user-util.h"
++#include "missing_stdlib.h"
+ 
+ #define log_debug_bus_message(m)                                         \
+         do {                                                             \
+diff --git a/src/libsystemd/sd-bus/test-bus-benchmark.c b/src/libsystemd/sd-bus/test-bus-benchmark.c
+index d988588de0..458df8df9a 100644
+--- a/src/libsystemd/sd-bus/test-bus-benchmark.c
++++ b/src/libsystemd/sd-bus/test-bus-benchmark.c
+@@ -14,6 +14,7 @@
+ #include "string-util.h"
+ #include "tests.h"
+ #include "time-util.h"
++#include "missing_stdlib.h"
+ 
+ #define MAX_SIZE (2*1024*1024)
+ 
+diff --git a/src/libsystemd/sd-journal/sd-journal.c b/src/libsystemd/sd-journal/sd-journal.c
+index 6b9ff0a4ed..4a5027ad0f 100644
+--- a/src/libsystemd/sd-journal/sd-journal.c
++++ b/src/libsystemd/sd-journal/sd-journal.c
+@@ -44,6 +44,7 @@
+ #include "strv.h"
+ #include "syslog-util.h"
+ #include "uid-alloc-range.h"
++#include "missing_stdlib.h"
+ 
+ #define JOURNAL_FILES_RECHECK_USEC (2 * USEC_PER_SEC)
+ 
+diff --git a/src/login/pam_systemd.c b/src/login/pam_systemd.c
+index b8da266e27..4bb8dd9496 100644
+--- a/src/login/pam_systemd.c
++++ b/src/login/pam_systemd.c
+@@ -35,6 +35,7 @@
+ #include "login-util.h"
+ #include "macro.h"
+ #include "missing_syscall.h"
++#include "missing_stdlib.h"
+ #include "pam-util.h"
+ #include "parse-util.h"
+ #include "path-util.h"
+diff --git a/src/network/generator/network-generator.c b/src/network/generator/network-generator.c
+index 48527a2c73..9777fe0561 100644
+--- a/src/network/generator/network-generator.c
++++ b/src/network/generator/network-generator.c
+@@ -14,6 +14,7 @@
+ #include "string-table.h"
+ #include "string-util.h"
+ #include "strv.h"
++#include "missing_stdlib.h"
+ 
+ /*
+   # .network
+diff --git a/src/nspawn/nspawn-settings.c b/src/nspawn/nspawn-settings.c
+index 161b1c1c70..ba1c459f78 100644
+--- a/src/nspawn/nspawn-settings.c
++++ b/src/nspawn/nspawn-settings.c
+@@ -16,6 +16,7 @@
+ #include "string-util.h"
+ #include "strv.h"
+ #include "user-util.h"
++#include "missing_stdlib.h"
+ 
+ Settings *settings_new(void) {
+         Settings *s;
+diff --git a/src/nss-mymachines/nss-mymachines.c b/src/nss-mymachines/nss-mymachines.c
+index c64e79bdff..eda26b0b9a 100644
+--- a/src/nss-mymachines/nss-mymachines.c
++++ b/src/nss-mymachines/nss-mymachines.c
+@@ -21,6 +21,7 @@
+ #include "nss-util.h"
+ #include "signal-util.h"
+ #include "string-util.h"
++#include "missing_stdlib.h"
+ 
+ static void setup_logging_once(void) {
+         static pthread_once_t once = PTHREAD_ONCE_INIT;
+diff --git a/src/portable/portable.c b/src/portable/portable.c
+index d4b448a627..bb26623565 100644
+--- a/src/portable/portable.c
++++ b/src/portable/portable.c
+@@ -40,6 +40,7 @@
+ #include "strv.h"
+ #include "tmpfile-util.h"
+ #include "user-util.h"
++#include "missing_stdlib.h"
+ 
+ /* Markers used in the first line of our 20-portable.conf unit file drop-in to determine, that a) the unit file was
+  * dropped there by the portable service logic and b) for which image it was dropped there. */
+diff --git a/src/resolve/resolvectl.c b/src/resolve/resolvectl.c
+index afa537f160..32ccee4ae5 100644
+--- a/src/resolve/resolvectl.c
++++ b/src/resolve/resolvectl.c
+@@ -48,6 +48,7 @@
+ #include "varlink.h"
+ #include "verb-log-control.h"
+ #include "verbs.h"
++#include "missing_stdlib.h"
+ 
+ static int arg_family = AF_UNSPEC;
+ static int arg_ifindex = 0;
+diff --git a/src/shared/bus-get-properties.c b/src/shared/bus-get-properties.c
+index 53e5d6b99f..851ecd5644 100644
+--- a/src/shared/bus-get-properties.c
++++ b/src/shared/bus-get-properties.c
+@@ -4,6 +4,7 @@
+ #include "rlimit-util.h"
+ #include "stdio-util.h"
+ #include "string-util.h"
++#include "missing_stdlib.h"
+ 
+ int bus_property_get_bool(
+                 sd_bus *bus,
+diff --git a/src/shared/bus-unit-procs.c b/src/shared/bus-unit-procs.c
+index 8b462b5627..183ce1c18e 100644
+--- a/src/shared/bus-unit-procs.c
++++ b/src/shared/bus-unit-procs.c
+@@ -11,6 +11,7 @@
+ #include "sort-util.h"
+ #include "string-util.h"
+ #include "terminal-util.h"
++#include "missing_stdlib.h"
+ 
+ struct CGroupInfo {
+         char *cgroup_path;
+diff --git a/src/shared/bus-unit-util.c b/src/shared/bus-unit-util.c
+index 4ee9706847..30c8084847 100644
+--- a/src/shared/bus-unit-util.c
++++ b/src/shared/bus-unit-util.c
+@@ -50,6 +50,7 @@
+ #include "unit-def.h"
+ #include "user-util.h"
+ #include "utf8.h"
++#include "missing_stdlib.h"
+ 
+ int bus_parse_unit_info(sd_bus_message *message, UnitInfo *u) {
+         assert(message);
+diff --git a/src/shared/bus-util.c b/src/shared/bus-util.c
+index 4123152d93..74f148c8b4 100644
+--- a/src/shared/bus-util.c
++++ b/src/shared/bus-util.c
+@@ -24,6 +24,7 @@
+ #include "path-util.h"
+ #include "socket-util.h"
+ #include "stdio-util.h"
++#include "missing_stdlib.h"
+ 
+ static int name_owner_change_callback(sd_bus_message *m, void *userdata, sd_bus_error *ret_error) {
+         sd_event *e = ASSERT_PTR(userdata);
+diff --git a/src/shared/dns-domain.c b/src/shared/dns-domain.c
+index b41c9b06ca..e69050a507 100644
+--- a/src/shared/dns-domain.c
++++ b/src/shared/dns-domain.c
+@@ -18,6 +18,7 @@
+ #include "string-util.h"
+ #include "strv.h"
+ #include "utf8.h"
++#include "missing_stdlib.h"
+ 
+ int dns_label_unescape(const char **name, char *dest, size_t sz, DNSLabelFlags flags) {
+         const char *n;
+diff --git a/src/shared/journal-importer.c b/src/shared/journal-importer.c
+index 83e9834bbf..74eaae6f5e 100644
+--- a/src/shared/journal-importer.c
++++ b/src/shared/journal-importer.c
+@@ -16,6 +16,7 @@
+ #include "string-util.h"
+ #include "strv.h"
+ #include "unaligned.h"
++#include "missing_stdlib.h"
+ 
+ enum {
+         IMPORTER_STATE_LINE = 0,    /* waiting to read, or reading line */
+diff --git a/src/shared/logs-show.c b/src/shared/logs-show.c
+index a5d04003bd..10392c132d 100644
+--- a/src/shared/logs-show.c
++++ b/src/shared/logs-show.c
+@@ -41,6 +41,7 @@
+ #include "time-util.h"
+ #include "utf8.h"
+ #include "web-util.h"
++#include "missing_stdlib.h"
+ 
+ /* up to three lines (each up to 100 characters) or 300 characters, whichever is less */
+ #define PRINT_LINE_THRESHOLD 3
+diff --git a/src/shared/pager.c b/src/shared/pager.c
+index 19deefab56..6b6d0af1a0 100644
+--- a/src/shared/pager.c
++++ b/src/shared/pager.c
+@@ -25,6 +25,7 @@
+ #include "string-util.h"
+ #include "strv.h"
+ #include "terminal-util.h"
++#include "missing_stdlib.h"
+ 
+ static pid_t pager_pid = 0;
+ 
+diff --git a/src/socket-proxy/socket-proxyd.c b/src/socket-proxy/socket-proxyd.c
+index 287fd6c181..8f8d5493da 100644
+--- a/src/socket-proxy/socket-proxyd.c
++++ b/src/socket-proxy/socket-proxyd.c
+@@ -27,6 +27,7 @@
+ #include "set.h"
+ #include "socket-util.h"
+ #include "string-util.h"
++#include "missing_stdlib.h"
+ 
+ #define BUFFER_SIZE (256 * 1024)
+ 
+diff --git a/src/test/test-hexdecoct.c b/src/test/test-hexdecoct.c
+index f884008660..987e180697 100644
+--- a/src/test/test-hexdecoct.c
++++ b/src/test/test-hexdecoct.c
+@@ -7,6 +7,7 @@
+ #include "macro.h"
+ #include "random-util.h"
+ #include "string-util.h"
++#include "missing_stdlib.h"
+ #include "tests.h"
+ 
+ TEST(hexchar) {
+diff --git a/src/udev/udev-builtin-net_id.c b/src/udev/udev-builtin-net_id.c
+index 91b40088f4..f528a46b8e 100644
+--- a/src/udev/udev-builtin-net_id.c
++++ b/src/udev/udev-builtin-net_id.c
+@@ -39,6 +39,7 @@
+ #include "strv.h"
+ #include "strxcpyx.h"
+ #include "udev-builtin.h"
++#include "missing_stdlib.h"
+ 
+ #define ONBOARD_14BIT_INDEX_MAX ((1U << 14) - 1)
+ #define ONBOARD_16BIT_INDEX_MAX ((1U << 16) - 1)
+diff --git a/src/udev/udev-builtin-path_id.c b/src/udev/udev-builtin-path_id.c
+index 467c9a6ad3..f74dae60af 100644
+--- a/src/udev/udev-builtin-path_id.c
++++ b/src/udev/udev-builtin-path_id.c
+@@ -24,6 +24,7 @@
+ #include "sysexits.h"
+ #include "udev-builtin.h"
+ #include "udev-util.h"
++#include "missing_stdlib.h"
+ 
+ _printf_(2,3)
+ static void path_prepend(char **path, const char *fmt, ...) {
+diff --git a/src/udev/udev-event.c b/src/udev/udev-event.c
+index ed22c8b679..19ebe20237 100644
+--- a/src/udev/udev-event.c
++++ b/src/udev/udev-event.c
+@@ -16,6 +16,7 @@
+ #include "udev-util.h"
+ #include "udev-watch.h"
+ #include "user-util.h"
++#include "missing_stdlib.h"
+ 
+ UdevEvent *udev_event_new(sd_device *dev, usec_t exec_delay_usec, sd_netlink *rtnl, int log_level) {
+         UdevEvent *event;
+diff --git a/src/udev/udev-rules.c b/src/udev/udev-rules.c
+index 5f12002394..febe345b4c 100644
+--- a/src/udev/udev-rules.c
++++ b/src/udev/udev-rules.c
+@@ -41,6 +41,7 @@
+ #include "udev-util.h"
+ #include "user-util.h"
+ #include "virt.h"
++#include "missing_stdlib.h"
+ 
+ #define RULES_DIRS ((const char* const*) CONF_PATHS_STRV("udev/rules.d"))
+ 
+-- 
+2.34.1
+

--- a/recipes-backports/sdbus-c++/sdbus-c++-libsystemd/0004-don-t-fail-if-GLOB_BRACE-and-GLOB_ALTDIRFUNC-is-not-.patch
+++ b/recipes-backports/sdbus-c++/sdbus-c++-libsystemd/0004-don-t-fail-if-GLOB_BRACE-and-GLOB_ALTDIRFUNC-is-not-.patch
@@ -1,0 +1,156 @@
+From 5325ab5813617f35f03806ec420829dde7104387 Mon Sep 17 00:00:00 2001
+From: Chen Qi <Qi.Chen@windriver.com>
+Date: Mon, 25 Feb 2019 14:56:21 +0800
+Subject: [PATCH 04/22] don't fail if GLOB_BRACE and GLOB_ALTDIRFUNC is not
+ defined
+
+If the standard library doesn't provide brace
+expansion users just won't get it.
+
+Dont use GNU GLOB extentions on non-glibc systems
+
+Conditionalize use of GLOB_ALTDIRFUNC
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+[rebased for systemd 243]
+Signed-off-by: Scott Murray <scott.murray@konsulko.com>
+---
+ src/basic/glob-util.c     | 12 ++++++++++++
+ src/test/test-glob-util.c | 16 ++++++++++++++++
+ src/tmpfiles/tmpfiles.c   | 10 ++++++++++
+ 3 files changed, 38 insertions(+)
+
+diff --git a/src/basic/glob-util.c b/src/basic/glob-util.c
+index 802ca8c655..23818a67c6 100644
+--- a/src/basic/glob-util.c
++++ b/src/basic/glob-util.c
+@@ -12,6 +12,12 @@
+ #include "path-util.h"
+ #include "strv.h"
+ 
++/* Don't fail if the standard library
++ * doesn't provide brace expansion */
++#ifndef GLOB_BRACE
++#define GLOB_BRACE 0
++#endif
++
+ static void closedir_wrapper(void* v) {
+         (void) closedir(v);
+ }
+@@ -19,6 +25,7 @@ static void closedir_wrapper(void* v) {
+ int safe_glob(const char *path, int flags, glob_t *pglob) {
+         int k;
+ 
++#ifdef GLOB_ALTDIRFUNC
+         /* We want to set GLOB_ALTDIRFUNC ourselves, don't allow it to be set. */
+         assert(!(flags & GLOB_ALTDIRFUNC));
+ 
+@@ -32,9 +39,14 @@ int safe_glob(const char *path, int flags, glob_t *pglob) {
+                 pglob->gl_lstat = lstat;
+         if (!pglob->gl_stat)
+                 pglob->gl_stat = stat;
++#endif
+ 
+         errno = 0;
++#ifdef GLOB_ALTDIRFUNC
+         k = glob(path, flags | GLOB_ALTDIRFUNC, NULL, pglob);
++#else
++        k = glob(path, flags, NULL, pglob);
++#endif
+         if (k == GLOB_NOMATCH)
+                 return -ENOENT;
+         if (k == GLOB_NOSPACE)
+diff --git a/src/test/test-glob-util.c b/src/test/test-glob-util.c
+index 9b3e73cce0..3790ba3be5 100644
+--- a/src/test/test-glob-util.c
++++ b/src/test/test-glob-util.c
+@@ -34,6 +34,12 @@ TEST(glob_first) {
+         assert_se(first == NULL);
+ }
+ 
++/* Don't fail if the standard library
++ * doesn't provide brace expansion */
++#ifndef GLOB_BRACE
++#define GLOB_BRACE 0
++#endif
++
+ TEST(glob_exists) {
+         char name[] = "/tmp/test-glob_exists.XXXXXX";
+         int fd = -EBADF;
+@@ -61,11 +67,13 @@ TEST(glob_no_dot) {
+         const char *fn;
+ 
+         _cleanup_globfree_ glob_t g = {
++#ifdef GLOB_ALTDIRFUNC
+                 .gl_closedir = closedir_wrapper,
+                 .gl_readdir = (struct dirent *(*)(void *)) readdir_no_dot,
+                 .gl_opendir = (void *(*)(const char *)) opendir,
+                 .gl_lstat = lstat,
+                 .gl_stat = stat,
++#endif
+         };
+ 
+         int r;
+@@ -73,11 +81,19 @@ TEST(glob_no_dot) {
+         assert_se(mkdtemp(template));
+ 
+         fn = strjoina(template, "/*");
++#ifdef GLOB_ALTDIRFUNC
+         r = glob(fn, GLOB_NOSORT|GLOB_BRACE|GLOB_ALTDIRFUNC, NULL, &g);
++#else
++        r = glob(fn, GLOB_NOSORT|GLOB_BRACE, NULL, &g);
++#endif
+         assert_se(r == GLOB_NOMATCH);
+ 
+         fn = strjoina(template, "/.*");
++#ifdef GLOB_ALTDIRFUNC
+         r = glob(fn, GLOB_NOSORT|GLOB_BRACE|GLOB_ALTDIRFUNC, NULL, &g);
++#else
++        r = glob(fn, GLOB_NOSORT|GLOB_BRACE, NULL, &g);
++#endif
+         assert_se(r == GLOB_NOMATCH);
+ 
+         (void) rm_rf(template, REMOVE_ROOT|REMOVE_PHYSICAL);
+diff --git a/src/tmpfiles/tmpfiles.c b/src/tmpfiles/tmpfiles.c
+index 230ec09b97..2cc5f391d7 100644
+--- a/src/tmpfiles/tmpfiles.c
++++ b/src/tmpfiles/tmpfiles.c
+@@ -73,6 +73,12 @@
+ #include "user-util.h"
+ #include "virt.h"
+ 
++/* Don't fail if the standard library
++ * doesn't provide brace expansion */
++#ifndef GLOB_BRACE
++#define GLOB_BRACE 0
++#endif
++
+ /* This reads all files listed in /etc/tmpfiles.d/?*.conf and creates
+  * them in the file system. This is intended to be used to create
+  * properly owned directories beneath /tmp, /var/tmp, /run, which are
+@@ -2434,7 +2440,9 @@ finish:
+ 
+ static int glob_item(Context *c, Item *i, action_t action) {
+         _cleanup_globfree_ glob_t g = {
++#ifdef GLOB_ALTDIRFUNC
+                 .gl_opendir = (void *(*)(const char *)) opendir_nomod,
++#endif
+         };
+         int r = 0, k;
+ 
+@@ -2461,7 +2469,9 @@ static int glob_item_recursively(
+                 fdaction_t action) {
+ 
+         _cleanup_globfree_ glob_t g = {
++#ifdef GLOB_ALTDIRFUNC
+                 .gl_opendir = (void *(*)(const char *)) opendir_nomod,
++#endif
+         };
+         int r = 0, k;
+ 
+-- 
+2.34.1
+

--- a/recipes-backports/sdbus-c++/sdbus-c++-libsystemd/0005-add-missing-FTW_-macros-for-musl.patch
+++ b/recipes-backports/sdbus-c++/sdbus-c++-libsystemd/0005-add-missing-FTW_-macros-for-musl.patch
@@ -1,0 +1,44 @@
+From dad7f897c0de654fa5592fda3e90f874639849f9 Mon Sep 17 00:00:00 2001
+From: Chen Qi <Qi.Chen@windriver.com>
+Date: Mon, 25 Feb 2019 15:00:06 +0800
+Subject: [PATCH 05/22] add missing FTW_ macros for musl
+
+This is to avoid build failures like below for musl.
+
+  locale-util.c:296:24: error: 'FTW_STOP' undeclared
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+---
+ src/basic/missing_type.h    | 4 ++++
+ src/test/test-recurse-dir.c | 1 +
+ 2 files changed, 5 insertions(+)
+
+diff --git a/src/basic/missing_type.h b/src/basic/missing_type.h
+index 6c0456349d..73a5b90e3c 100644
+--- a/src/basic/missing_type.h
++++ b/src/basic/missing_type.h
+@@ -14,3 +14,7 @@
+ #ifndef __GLIBC__
+ typedef int (*comparison_fn_t)(const void *, const void *);
+ #endif
++
++#ifndef FTW_CONTINUE
++#define FTW_CONTINUE 0
++#endif
+diff --git a/src/test/test-recurse-dir.c b/src/test/test-recurse-dir.c
+index 8684d064ec..70fc2b5376 100644
+--- a/src/test/test-recurse-dir.c
++++ b/src/test/test-recurse-dir.c
+@@ -8,6 +8,7 @@
+ #include "recurse-dir.h"
+ #include "strv.h"
+ #include "tests.h"
++#include "missing_type.h"
+ 
+ static char **list_nftw = NULL;
+ 
+-- 
+2.34.1
+

--- a/recipes-backports/sdbus-c++/sdbus-c++-libsystemd/0006-Use-uintmax_t-for-handling-rlim_t.patch
+++ b/recipes-backports/sdbus-c++/sdbus-c++-libsystemd/0006-Use-uintmax_t-for-handling-rlim_t.patch
@@ -1,0 +1,106 @@
+From 96e975a2412a20e5f80bd3ab144057d275eb8597 Mon Sep 17 00:00:00 2001
+From: Chen Qi <Qi.Chen@windriver.com>
+Date: Mon, 25 Feb 2019 15:12:41 +0800
+Subject: [PATCH 06/22] Use uintmax_t for handling rlim_t
+
+PRIu{32,64} is not right format to represent rlim_t type
+therefore use %ju and typecast the rlim_t variables to
+uintmax_t.
+
+Fixes portablility errors like
+
+execute.c:3446:36: error: format '%lu' expects argument of type 'long unsigned int', but argument 5 has type 'rlim_t {aka long long unsigned int}' [-Werror=format=]
+|                          fprintf(f, "%s%s: " RLIM_FMT "\n",
+|                                     ^~~~~~~~
+|                                  prefix, rlimit_to_string(i), c->rlimit[i]->rlim_max);
+|                                                               ~~~~~~~~~~~~~~~~~~~~~~
+
+Upstream-Status: Denied [https://github.com/systemd/systemd/pull/7199]
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+[Rebased for v241]
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+---
+ src/basic/format-util.h |  8 +-------
+ src/basic/rlimit-util.c | 12 ++++++------
+ src/core/execute.c      |  4 ++--
+ 3 files changed, 9 insertions(+), 15 deletions(-)
+
+diff --git a/src/basic/format-util.h b/src/basic/format-util.h
+index 8719df3e29..9becc96066 100644
+--- a/src/basic/format-util.h
++++ b/src/basic/format-util.h
+@@ -34,13 +34,7 @@ assert_cc(sizeof(gid_t) == sizeof(uint32_t));
+ #  error Unknown timex member size
+ #endif
+ 
+-#if SIZEOF_RLIM_T == 8
+-#  define RLIM_FMT "%" PRIu64
+-#elif SIZEOF_RLIM_T == 4
+-#  define RLIM_FMT "%" PRIu32
+-#else
+-#  error Unknown rlim_t size
+-#endif
++#define RLIM_FMT "%ju"
+ 
+ #if SIZEOF_DEV_T == 8
+ #  define DEV_FMT "%" PRIu64
+diff --git a/src/basic/rlimit-util.c b/src/basic/rlimit-util.c
+index c1f0b2b974..61c5412582 100644
+--- a/src/basic/rlimit-util.c
++++ b/src/basic/rlimit-util.c
+@@ -44,7 +44,7 @@ int setrlimit_closest(int resource, const struct rlimit *rlim) {
+             fixed.rlim_max == highest.rlim_max)
+                 return 0;
+ 
+-        log_debug("Failed at setting rlimit " RLIM_FMT " for resource RLIMIT_%s. Will attempt setting value " RLIM_FMT " instead.", rlim->rlim_max, rlimit_to_string(resource), fixed.rlim_max);
++        log_debug("Failed at setting rlimit " RLIM_FMT " for resource RLIMIT_%s. Will attempt setting value " RLIM_FMT " instead.", (uintmax_t)rlim->rlim_max, rlimit_to_string(resource), (uintmax_t)fixed.rlim_max);
+ 
+         return RET_NERRNO(setrlimit(resource, &fixed));
+ }
+@@ -307,13 +307,13 @@ int rlimit_format(const struct rlimit *rl, char **ret) {
+         if (rl->rlim_cur >= RLIM_INFINITY && rl->rlim_max >= RLIM_INFINITY)
+                 r = free_and_strdup(&s, "infinity");
+         else if (rl->rlim_cur >= RLIM_INFINITY)
+-                r = asprintf(&s, "infinity:" RLIM_FMT, rl->rlim_max);
++                r = asprintf(&s, "infinity:" RLIM_FMT, (uintmax_t)rl->rlim_max);
+         else if (rl->rlim_max >= RLIM_INFINITY)
+-                r = asprintf(&s, RLIM_FMT ":infinity", rl->rlim_cur);
++                r = asprintf(&s, RLIM_FMT ":infinity", (uintmax_t)rl->rlim_cur);
+         else if (rl->rlim_cur == rl->rlim_max)
+-                r = asprintf(&s, RLIM_FMT, rl->rlim_cur);
++                r = asprintf(&s, RLIM_FMT, (uintmax_t)rl->rlim_cur);
+         else
+-                r = asprintf(&s, RLIM_FMT ":" RLIM_FMT, rl->rlim_cur, rl->rlim_max);
++                r = asprintf(&s, RLIM_FMT ":" RLIM_FMT, (uintmax_t)rl->rlim_cur, (uintmax_t)rl->rlim_max);
+         if (r < 0)
+                 return -ENOMEM;
+ 
+@@ -422,7 +422,7 @@ int rlimit_nofile_safe(void) {
+         rl.rlim_max = MIN(rl.rlim_max, (rlim_t) read_nr_open());
+         rl.rlim_cur = MIN((rlim_t) FD_SETSIZE, rl.rlim_max);
+         if (setrlimit(RLIMIT_NOFILE, &rl) < 0)
+-                return log_debug_errno(errno, "Failed to lower RLIMIT_NOFILE's soft limit to " RLIM_FMT ": %m", rl.rlim_cur);
++                return log_debug_errno(errno, "Failed to lower RLIMIT_NOFILE's soft limit to " RLIM_FMT ": %m", (uintmax_t)rl.rlim_cur);
+ 
+         return 1;
+ }
+diff --git a/src/core/execute.c b/src/core/execute.c
+index bd3da0c401..df1870fd2f 100644
+--- a/src/core/execute.c
++++ b/src/core/execute.c
+@@ -1045,9 +1045,9 @@ void exec_context_dump(const ExecContext *c, FILE* f, const char *prefix) {
+         for (unsigned i = 0; i < RLIM_NLIMITS; i++)
+                 if (c->rlimit[i]) {
+                         fprintf(f, "%sLimit%s: " RLIM_FMT "\n",
+-                                prefix, rlimit_to_string(i), c->rlimit[i]->rlim_max);
++                                prefix, rlimit_to_string(i), (uintmax_t)c->rlimit[i]->rlim_max);
+                         fprintf(f, "%sLimit%sSoft: " RLIM_FMT "\n",
+-                                prefix, rlimit_to_string(i), c->rlimit[i]->rlim_cur);
++                                prefix, rlimit_to_string(i), (uintmax_t)c->rlimit[i]->rlim_cur);
+                 }
+ 
+         if (c->ioprio_set) {
+-- 
+2.34.1
+

--- a/recipes-backports/sdbus-c++/sdbus-c++-libsystemd/0007-don-t-pass-AT_SYMLINK_NOFOLLOW-flag-to-faccessat.patch
+++ b/recipes-backports/sdbus-c++/sdbus-c++-libsystemd/0007-don-t-pass-AT_SYMLINK_NOFOLLOW-flag-to-faccessat.patch
@@ -1,0 +1,99 @@
+From 4842cff4f1329f0b5034b529d56f8ad1f234ac4c Mon Sep 17 00:00:00 2001
+From: Andre McCurdy <armccurdy@gmail.com>
+Date: Tue, 10 Oct 2017 14:33:30 -0700
+Subject: [PATCH 07/22] don't pass AT_SYMLINK_NOFOLLOW flag to faccessat()
+
+Avoid using AT_SYMLINK_NOFOLLOW flag. It doesn't seem like the right
+thing to do and it's not portable (not supported by musl). See:
+
+  http://lists.landley.net/pipermail/toybox-landley.net/2014-September/003610.html
+  http://www.openwall.com/lists/musl/2015/02/05/2
+
+Note that laccess() is never passing AT_EACCESS so a lot of the
+discussion in the links above doesn't apply. Note also that
+(currently) all systemd callers of laccess() pass mode as F_OK, so
+only check for existence of a file, not access permissions.
+Therefore, in this case, the only distiction between faccessat()
+with (flag == 0) and (flag == AT_SYMLINK_NOFOLLOW) is the behaviour
+for broken symlinks; laccess() on a broken symlink will succeed with
+(flag == AT_SYMLINK_NOFOLLOW) and fail (flag == 0).
+
+The laccess() macros was added to systemd some time ago and it's not
+clear if or why it needs to return success for broken symlinks. Maybe
+just historical and not actually necessary or desired behaviour?
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Andre McCurdy <armccurdy@gmail.com>
+---
+ src/basic/fs-util.h          | 21 ++++++++++++++++++++-
+ src/shared/base-filesystem.c |  6 +++---
+ 2 files changed, 23 insertions(+), 4 deletions(-)
+
+diff --git a/src/basic/fs-util.h b/src/basic/fs-util.h
+index 1023ab73ca..c78ff6f27f 100644
+--- a/src/basic/fs-util.h
++++ b/src/basic/fs-util.h
+@@ -49,8 +49,27 @@ int futimens_opath(int fd, const struct timespec ts[2]);
+ int fd_warn_permissions(const char *path, int fd);
+ int stat_warn_permissions(const char *path, const struct stat *st);
+ 
++/*
++   Avoid using AT_SYMLINK_NOFOLLOW flag. It doesn't seem like the right thing to
++   do and it's not portable (not supported by musl). See:
++
++     http://lists.landley.net/pipermail/toybox-landley.net/2014-September/003610.html
++     http://www.openwall.com/lists/musl/2015/02/05/2
++
++   Note that laccess() is never passing AT_EACCESS so a lot of the discussion in
++   the links above doesn't apply. Note also that (currently) all systemd callers
++   of laccess() pass mode as F_OK, so only check for existence of a file, not
++   access permissions. Therefore, in this case, the only distiction between
++   faccessat() with (flag == 0) and (flag == AT_SYMLINK_NOFOLLOW) is the
++   behaviour for broken symlinks; laccess() on a broken symlink will succeed
++   with (flag == AT_SYMLINK_NOFOLLOW) and fail (flag == 0).
++
++   The laccess() macros was added to systemd some time ago and it's not clear if
++   or why it needs to return success for broken symlinks. Maybe just historical
++   and not actually necessary or desired behaviour?
++*/
+ #define laccess(path, mode)                                             \
+-        RET_NERRNO(faccessat(AT_FDCWD, (path), (mode), AT_SYMLINK_NOFOLLOW))
++        RET_NERRNO(faccessat(AT_FDCWD, (path), (mode), 0))
+ 
+ int touch_file(const char *path, bool parents, usec_t stamp, uid_t uid, gid_t gid, mode_t mode);
+ 
+diff --git a/src/shared/base-filesystem.c b/src/shared/base-filesystem.c
+index 569ef466c3..7ae921a113 100644
+--- a/src/shared/base-filesystem.c
++++ b/src/shared/base-filesystem.c
+@@ -145,7 +145,7 @@ int base_filesystem_create_fd(int fd, const char *root, uid_t uid, gid_t gid) {
+         /* The "root" parameter is decoration only – it's only used as part of log messages */
+ 
+         for (size_t i = 0; i < ELEMENTSOF(table); i++) {
+-                if (faccessat(fd, table[i].dir, F_OK, AT_SYMLINK_NOFOLLOW) >= 0)
++                if (faccessat(fd, table[i].dir, F_OK, 0) >= 0)
+                         continue;
+ 
+                 if (table[i].target) { /* Create as symlink? */
+@@ -153,7 +153,7 @@ int base_filesystem_create_fd(int fd, const char *root, uid_t uid, gid_t gid) {
+ 
+                         /* check if one of the targets exists */
+                         NULSTR_FOREACH(s, table[i].target) {
+-                                if (faccessat(fd, s, F_OK, AT_SYMLINK_NOFOLLOW) < 0)
++                                if (faccessat(fd, s, F_OK, 0) < 0)
+                                         continue;
+ 
+                                 /* check if a specific file exists at the target path */
+@@ -164,7 +164,7 @@ int base_filesystem_create_fd(int fd, const char *root, uid_t uid, gid_t gid) {
+                                         if (!p)
+                                                 return log_oom();
+ 
+-                                        if (faccessat(fd, p, F_OK, AT_SYMLINK_NOFOLLOW) < 0)
++                                        if (faccessat(fd, p, F_OK, 0) < 0)
+                                                 continue;
+                                 }
+ 
+-- 
+2.34.1
+

--- a/recipes-backports/sdbus-c++/sdbus-c++-libsystemd/0008-Define-glibc-compatible-basename-for-non-glibc-syste.patch
+++ b/recipes-backports/sdbus-c++/sdbus-c++-libsystemd/0008-Define-glibc-compatible-basename-for-non-glibc-syste.patch
@@ -1,0 +1,34 @@
+From bab07e779ff23d5593bb118efaaa31b60a6dce87 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sun, 27 May 2018 08:36:44 -0700
+Subject: [PATCH 08/22] Define glibc compatible basename() for non-glibc
+ systems
+
+Fixes builds with musl, even though systemd is adamant about
+using non-posix basename implementation, we have a way out
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ src/basic/string-util.h | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/basic/string-util.h b/src/basic/string-util.h
+index b6d8be3083..0a29036c4c 100644
+--- a/src/basic/string-util.h
++++ b/src/basic/string-util.h
+@@ -26,6 +26,10 @@
+ #define URI_UNRESERVED      ALPHANUMERICAL "-._~"       /* [RFC3986] */
+ #define URI_VALID           URI_RESERVED URI_UNRESERVED /* [RFC3986] */
+ 
++#if !defined(__GLIBC__)
++#define basename(src) (strrchr(src,'/') ? strrchr(src,'/')+1 : src)
++#endif
++
+ static inline char* strstr_ptr(const char *haystack, const char *needle) {
+         if (!haystack || !needle)
+                 return NULL;
+-- 
+2.34.1
+

--- a/recipes-backports/sdbus-c++/sdbus-c++-libsystemd/0008-implment-systemd-sysv-install-for-OE.patch
+++ b/recipes-backports/sdbus-c++/sdbus-c++-libsystemd/0008-implment-systemd-sysv-install-for-OE.patch
@@ -1,0 +1,43 @@
+From 5712d56f1cd654d2e5d2e9117ff77fe4c299f76b Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sat, 5 Sep 2015 06:31:47 +0000
+Subject: [PATCH] implment systemd-sysv-install for OE
+
+Use update-rc.d for enabling/disabling and status command
+to check the status of the sysv service
+
+Upstream-Status: Inappropriate [OE-Specific]
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ src/systemctl/systemd-sysv-install.SKELETON | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/systemctl/systemd-sysv-install.SKELETON b/src/systemctl/systemd-sysv-install.SKELETON
+index cb58d8243b..000bdf6165 100755
+--- a/src/systemctl/systemd-sysv-install.SKELETON
++++ b/src/systemctl/systemd-sysv-install.SKELETON
+@@ -34,17 +34,17 @@ case "$1" in
+     enable)
+         # call the command to enable SysV init script $NAME here
+         # (consider optional $ROOT)
+-        echo "IMPLEMENT ME: enabling SysV init.d script $NAME"
++        update-rc.d -f $NAME defaults
+         ;;
+     disable)
+         # call the command to disable SysV init script $NAME here
+         # (consider optional $ROOT)
+-        echo "IMPLEMENT ME: disabling SysV init.d script $NAME"
++        update-rc.d -f $NAME remove
+         ;;
+     is-enabled)
+         # exit with 0 if $NAME is enabled, non-zero if it is disabled
+         # (consider optional $ROOT)
+-        echo "IMPLEMENT ME: checking SysV init.d script $NAME"
++        /etc/init.d/$NAME status
+         ;;
+     *)
+         usage ;;
+-- 
+2.39.2
+

--- a/recipes-backports/sdbus-c++/sdbus-c++-libsystemd/0009-Do-not-disable-buffering-when-writing-to-oom_score_a.patch
+++ b/recipes-backports/sdbus-c++/sdbus-c++-libsystemd/0009-Do-not-disable-buffering-when-writing-to-oom_score_a.patch
@@ -1,0 +1,41 @@
+From 25093c5017725b8577c444dfea0f42ad85b43522 Mon Sep 17 00:00:00 2001
+From: Chen Qi <Qi.Chen@windriver.com>
+Date: Wed, 4 Jul 2018 15:00:44 +0800
+Subject: [PATCH 09/22] Do not disable buffering when writing to oom_score_adj
+
+On musl, disabling buffering when writing to oom_score_adj will
+cause the following error.
+
+  Failed to adjust OOM setting: Invalid argument
+
+This error appears for systemd-udevd.service and dbus.service.
+This is because kernel receives '-' instead of the whole '-900'
+if buffering is disabled.
+
+This is libc implementation specific, as glibc does not have this issue.
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+[rebased for systemd 243]
+Signed-off-by: Scott Murray <scott.murray@konsulko.com>
+---
+ src/basic/process-util.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/basic/process-util.c b/src/basic/process-util.c
+index 201c5596ae..ea51595b6c 100644
+--- a/src/basic/process-util.c
++++ b/src/basic/process-util.c
+@@ -1716,7 +1716,7 @@ int set_oom_score_adjust(int value) {
+         xsprintf(t, "%i", value);
+ 
+         return write_string_file("/proc/self/oom_score_adj", t,
+-                                 WRITE_STRING_FILE_VERIFY_ON_FAILURE|WRITE_STRING_FILE_DISABLE_BUFFER);
++                                 WRITE_STRING_FILE_VERIFY_ON_FAILURE);
+ }
+ 
+ int get_oom_score_adjust(int *ret) {
+-- 
+2.34.1
+

--- a/recipes-backports/sdbus-c++/sdbus-c++-libsystemd/0010-distinguish-XSI-compliant-strerror_r-from-GNU-specif.patch
+++ b/recipes-backports/sdbus-c++/sdbus-c++-libsystemd/0010-distinguish-XSI-compliant-strerror_r-from-GNU-specif.patch
@@ -1,0 +1,76 @@
+From 2adbe9773cd65c48eec9df96868d4a738927c8d9 Mon Sep 17 00:00:00 2001
+From: Chen Qi <Qi.Chen@windriver.com>
+Date: Tue, 10 Jul 2018 15:40:17 +0800
+Subject: [PATCH 10/22] distinguish XSI-compliant strerror_r from GNU-specifi
+ strerror_r
+
+XSI-compliant strerror_r and GNU-specifi strerror_r are different.
+
+       int strerror_r(int errnum, char *buf, size_t buflen);
+                   /* XSI-compliant */
+
+       char *strerror_r(int errnum, char *buf, size_t buflen);
+                   /* GNU-specific */
+
+We need to distinguish between them. Otherwise, we'll get an int value
+assigned to (char *) variable, resulting in segment fault.
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+---
+ src/libsystemd/sd-bus/bus-error.c        | 11 ++++++++++-
+ src/libsystemd/sd-journal/journal-send.c |  5 +++++
+ 2 files changed, 15 insertions(+), 1 deletion(-)
+
+diff --git a/src/libsystemd/sd-bus/bus-error.c b/src/libsystemd/sd-bus/bus-error.c
+index 77b2e1a0fd..fdba0e0142 100644
+--- a/src/libsystemd/sd-bus/bus-error.c
++++ b/src/libsystemd/sd-bus/bus-error.c
+@@ -408,7 +408,12 @@ static void bus_error_strerror(sd_bus_error *e, int error) {
+                         return;
+ 
+                 errno = 0;
++#ifndef __GLIBC__
++                strerror_r(error, m, k);
++                x = m;
++#else
+                 x = strerror_r(error, m, k);
++#endif
+                 if (errno == ERANGE || strlen(x) >= k - 1) {
+                         free(m);
+                         k *= 2;
+@@ -593,8 +598,12 @@ const char* _bus_error_message(const sd_bus_error *e, int error, char buf[static
+ 
+         if (e && e->message)
+                 return e->message;
+-
++#ifndef __GLIBC__
++        strerror_r(abs(error), buf, ERRNO_BUF_LEN);
++        return buf;
++#else
+         return strerror_r(abs(error), buf, ERRNO_BUF_LEN);
++#endif
+ }
+ 
+ static bool map_ok(const sd_bus_error_map *map) {
+diff --git a/src/libsystemd/sd-journal/journal-send.c b/src/libsystemd/sd-journal/journal-send.c
+index 69a2eb6404..1561859650 100644
+--- a/src/libsystemd/sd-journal/journal-send.c
++++ b/src/libsystemd/sd-journal/journal-send.c
+@@ -361,7 +361,12 @@ static int fill_iovec_perror_and_send(const char *message, int skip, struct iove
+                 char* j;
+ 
+                 errno = 0;
++#ifndef __GLIBC__
++                strerror_r(_saved_errno_, buffer + 8 + k, n - 8 - k);
++                j = buffer + 8 + k;
++#else
+                 j = strerror_r(_saved_errno_, buffer + 8 + k, n - 8 - k);
++#endif
+                 if (errno == 0) {
+                         char error[STRLEN("ERRNO=") + DECIMAL_STR_MAX(int) + 1];
+ 
+-- 
+2.34.1
+

--- a/recipes-backports/sdbus-c++/sdbus-c++-libsystemd/0011-avoid-redefinition-of-prctl_mm_map-structure.patch
+++ b/recipes-backports/sdbus-c++/sdbus-c++-libsystemd/0011-avoid-redefinition-of-prctl_mm_map-structure.patch
@@ -1,0 +1,32 @@
+From 49c446cfb78cf74a909bed8c3798b77a5469866a Mon Sep 17 00:00:00 2001
+From: Chen Qi <Qi.Chen@windriver.com>
+Date: Mon, 25 Feb 2019 15:44:54 +0800
+Subject: [PATCH 11/22] avoid redefinition of prctl_mm_map structure
+
+Fix the following compile failure:
+error: redefinition of 'struct prctl_mm_map'
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+---
+ src/basic/missing_prctl.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/basic/missing_prctl.h b/src/basic/missing_prctl.h
+index 7d9e395c92..88c2d7dfac 100644
+--- a/src/basic/missing_prctl.h
++++ b/src/basic/missing_prctl.h
+@@ -1,7 +1,9 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+ #pragma once
+ 
++#ifdef __GLIBC__
+ #include <linux/prctl.h>
++#endif
+ 
+ /* 58319057b7847667f0c9585b9de0e8932b0fdb08 (4.3) */
+ #ifndef PR_CAP_AMBIENT
+-- 
+2.34.1
+

--- a/recipes-backports/sdbus-c++/sdbus-c++-libsystemd/0012-do-not-disable-buffer-in-writing-files.patch
+++ b/recipes-backports/sdbus-c++/sdbus-c++-libsystemd/0012-do-not-disable-buffer-in-writing-files.patch
@@ -1,0 +1,562 @@
+From e4885a8e60f883d9217e26e1db3754c2906aca31 Mon Sep 17 00:00:00 2001
+From: Chen Qi <Qi.Chen@windriver.com>
+Date: Fri, 1 Mar 2019 15:22:15 +0800
+Subject: [PATCH 12/22] do not disable buffer in writing files
+
+Do not disable buffer in writing files, otherwise we get
+failure at boot for musl like below.
+
+  [!!!!!!] Failed to allocate manager object.
+
+And there will be other failures, critical or not critical.
+This is specific to musl.
+
+Upstream-Status: Inappropriate [musl]
+
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+[Rebased for v242]
+Signed-off-by: Andrej Valek <andrej.valek@siemens.com>
+[rebased for systemd 243]
+Signed-off-by: Scott Murray <scott.murray@konsulko.com>
+[rebased for systemd 254]
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+[rebased for systemd 255.1]
+---
+ src/basic/cgroup-util.c              | 12 ++++++------
+ src/basic/namespace-util.c           |  4 ++--
+ src/basic/procfs-util.c              |  4 ++--
+ src/basic/sysctl-util.c              |  2 +-
+ src/binfmt/binfmt.c                  |  6 +++---
+ src/core/cgroup.c                    |  2 +-
+ src/core/main.c                      |  2 +-
+ src/core/smack-setup.c               |  8 ++++----
+ src/home/homework.c                  |  2 +-
+ src/libsystemd/sd-device/sd-device.c |  2 +-
+ src/nspawn/nspawn-cgroup.c           |  2 +-
+ src/nspawn/nspawn.c                  |  6 +++---
+ src/shared/binfmt-util.c             |  2 +-
+ src/shared/cgroup-setup.c            |  4 ++--
+ src/shared/coredump-util.c           |  4 ++--
+ src/shared/hibernate-util.c          |  4 ++--
+ src/shared/smack-util.c              |  2 +-
+ src/shared/watchdog.c                |  2 +-
+ src/sleep/sleep.c                    |  4 ++--
+ src/storagetm/storagetm.c            | 24 ++++++++++++------------
+ src/udev/udev-rules.c                |  1 -
+ src/vconsole/vconsole-setup.c        |  2 +-
+ 22 files changed, 50 insertions(+), 51 deletions(-)
+
+diff --git a/src/basic/cgroup-util.c b/src/basic/cgroup-util.c
+index d2be79622f..e65fecb68d 100644
+--- a/src/basic/cgroup-util.c
++++ b/src/basic/cgroup-util.c
+@@ -417,7 +417,7 @@ int cg_kill_kernel_sigkill(const char *path) {
+         if (r < 0)
+                 return r;
+ 
+-        r = write_string_file(killfile, "1", WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file(killfile, "1", 0);
+         if (r < 0)
+                 return r;
+ 
+@@ -843,7 +843,7 @@ int cg_install_release_agent(const char *controller, const char *agent) {
+ 
+         sc = strstrip(contents);
+         if (isempty(sc)) {
+-                r = write_string_file(fs, agent, WRITE_STRING_FILE_DISABLE_BUFFER);
++                r = write_string_file(fs, agent, 0);
+                 if (r < 0)
+                         return r;
+         } else if (!path_equal(sc, agent))
+@@ -861,7 +861,7 @@ int cg_install_release_agent(const char *controller, const char *agent) {
+ 
+         sc = strstrip(contents);
+         if (streq(sc, "0")) {
+-                r = write_string_file(fs, "1", WRITE_STRING_FILE_DISABLE_BUFFER);
++                r = write_string_file(fs, "1", 0);
+                 if (r < 0)
+                         return r;
+ 
+@@ -888,7 +888,7 @@ int cg_uninstall_release_agent(const char *controller) {
+         if (r < 0)
+                 return r;
+ 
+-        r = write_string_file(fs, "0", WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file(fs, "0", 0);
+         if (r < 0)
+                 return r;
+ 
+@@ -898,7 +898,7 @@ int cg_uninstall_release_agent(const char *controller) {
+         if (r < 0)
+                 return r;
+ 
+-        r = write_string_file(fs, "", WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file(fs, "", 0);
+         if (r < 0)
+                 return r;
+ 
+@@ -1814,7 +1814,7 @@ int cg_set_attribute(const char *controller, const char *path, const char *attri
+         if (r < 0)
+                 return r;
+ 
+-        return write_string_file(p, value, WRITE_STRING_FILE_DISABLE_BUFFER);
++        return write_string_file(p, value, 0);
+ }
+ 
+ int cg_get_attribute(const char *controller, const char *path, const char *attribute, char **ret) {
+diff --git a/src/basic/namespace-util.c b/src/basic/namespace-util.c
+index 2101f617ad..63817bae17 100644
+--- a/src/basic/namespace-util.c
++++ b/src/basic/namespace-util.c
+@@ -227,12 +227,12 @@ int userns_acquire(const char *uid_map, const char *gid_map) {
+                 freeze();
+ 
+         xsprintf(path, "/proc/" PID_FMT "/uid_map", pid);
+-        r = write_string_file(path, uid_map, WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file(path, uid_map, 0);
+         if (r < 0)
+                 return log_error_errno(r, "Failed to write UID map: %m");
+ 
+         xsprintf(path, "/proc/" PID_FMT "/gid_map", pid);
+-        r = write_string_file(path, gid_map, WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file(path, gid_map, 0);
+         if (r < 0)
+                 return log_error_errno(r, "Failed to write GID map: %m");
+ 
+diff --git a/src/basic/procfs-util.c b/src/basic/procfs-util.c
+index 6cb0ddf575..247cf9e1d1 100644
+--- a/src/basic/procfs-util.c
++++ b/src/basic/procfs-util.c
+@@ -64,13 +64,13 @@ int procfs_tasks_set_limit(uint64_t limit) {
+          * decrease it, as threads-max is the much more relevant sysctl. */
+         if (limit > pid_max-1) {
+                 sprintf(buffer, "%" PRIu64, limit+1); /* Add one, since PID 0 is not a valid PID */
+-                r = write_string_file("/proc/sys/kernel/pid_max", buffer, WRITE_STRING_FILE_DISABLE_BUFFER);
++                r = write_string_file("/proc/sys/kernel/pid_max", buffer, 0);
+                 if (r < 0)
+                         return r;
+         }
+ 
+         sprintf(buffer, "%" PRIu64, limit);
+-        r = write_string_file("/proc/sys/kernel/threads-max", buffer, WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file("/proc/sys/kernel/threads-max", buffer, 0);
+         if (r < 0) {
+                 uint64_t threads_max;
+ 
+diff --git a/src/basic/sysctl-util.c b/src/basic/sysctl-util.c
+index b66a6622ae..8d1c93008a 100644
+--- a/src/basic/sysctl-util.c
++++ b/src/basic/sysctl-util.c
+@@ -58,7 +58,7 @@ int sysctl_write(const char *property, const char *value) {
+ 
+         log_debug("Setting '%s' to '%s'", p, value);
+ 
+-        return write_string_file(p, value, WRITE_STRING_FILE_VERIFY_ON_FAILURE | WRITE_STRING_FILE_DISABLE_BUFFER | WRITE_STRING_FILE_SUPPRESS_REDUNDANT_VIRTUAL);
++        return write_string_file(p, value, WRITE_STRING_FILE_VERIFY_ON_FAILURE | WRITE_STRING_FILE_SUPPRESS_REDUNDANT_VIRTUAL);
+ }
+ 
+ int sysctl_writef(const char *property, const char *format, ...) {
+diff --git a/src/binfmt/binfmt.c b/src/binfmt/binfmt.c
+index d21f3f79ff..258607cc7e 100644
+--- a/src/binfmt/binfmt.c
++++ b/src/binfmt/binfmt.c
+@@ -30,7 +30,7 @@ static bool arg_unregister = false;
+ 
+ static int delete_rule(const char *rulename) {
+         const char *fn = strjoina("/proc/sys/fs/binfmt_misc/", rulename);
+-        return write_string_file(fn, "-1", WRITE_STRING_FILE_DISABLE_BUFFER);
++        return write_string_file(fn, "-1", 0);
+ }
+ 
+ static int apply_rule(const char *filename, unsigned line, const char *rule) {
+@@ -58,7 +58,7 @@ static int apply_rule(const char *filename, unsigned line, const char *rule) {
+         if (r >= 0)
+                 log_debug("%s:%u: Rule '%s' deleted.", filename, line, rulename);
+ 
+-        r = write_string_file("/proc/sys/fs/binfmt_misc/register", rule, WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file("/proc/sys/fs/binfmt_misc/register", rule, 0);
+         if (r < 0)
+                 return log_error_errno(r, "%s:%u: Failed to add binary format '%s': %m",
+                                        filename, line, rulename);
+@@ -248,7 +248,7 @@ static int run(int argc, char *argv[]) {
+                         return r;
+ 
+                 /* Flush out all rules */
+-                r = write_string_file("/proc/sys/fs/binfmt_misc/status", "-1", WRITE_STRING_FILE_DISABLE_BUFFER);
++                r = write_string_file("/proc/sys/fs/binfmt_misc/status", "-1", 0);
+                 if (r < 0)
+                         log_warning_errno(r, "Failed to flush binfmt_misc rules, ignoring: %m");
+                 else
+diff --git a/src/core/cgroup.c b/src/core/cgroup.c
+index 61ac4df1a6..ea18970196 100644
+--- a/src/core/cgroup.c
++++ b/src/core/cgroup.c
+@@ -4578,7 +4578,7 @@ int unit_cgroup_freezer_action(Unit *u, FreezerAction action) {
+                         u->freezer_state = FREEZER_THAWING;
+         }
+ 
+-        r = write_string_file(path, one_zero(action == FREEZER_FREEZE), WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file(path, one_zero(action == FREEZER_FREEZE), 0);
+         if (r < 0)
+                 return r;
+ 
+diff --git a/src/core/main.c b/src/core/main.c
+index 3f71cc0947..0e5aec3e9e 100644
+--- a/src/core/main.c
++++ b/src/core/main.c
+@@ -1678,7 +1678,7 @@ static void initialize_core_pattern(bool skip_setup) {
+         if (getpid_cached() != 1)
+                 return;
+ 
+-        r = write_string_file("/proc/sys/kernel/core_pattern", arg_early_core_pattern, WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file("/proc/sys/kernel/core_pattern", arg_early_core_pattern, 0);
+         if (r < 0)
+                 log_warning_errno(r, "Failed to write '%s' to /proc/sys/kernel/core_pattern, ignoring: %m",
+                                   arg_early_core_pattern);
+diff --git a/src/core/smack-setup.c b/src/core/smack-setup.c
+index 7ea902b6f9..1aef2988d0 100644
+--- a/src/core/smack-setup.c
++++ b/src/core/smack-setup.c
+@@ -321,17 +321,17 @@ int mac_smack_setup(bool *loaded_policy) {
+         }
+ 
+ #if HAVE_SMACK_RUN_LABEL
+-        r = write_string_file("/proc/self/attr/current", SMACK_RUN_LABEL, WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file("/proc/self/attr/current", SMACK_RUN_LABEL, 0);
+         if (r < 0)
+                 log_warning_errno(r, "Failed to set SMACK label \"" SMACK_RUN_LABEL "\" on self: %m");
+-        r = write_string_file("/sys/fs/smackfs/ambient", SMACK_RUN_LABEL, WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file("/sys/fs/smackfs/ambient", SMACK_RUN_LABEL, 0);
+         if (r < 0)
+                 log_warning_errno(r, "Failed to set SMACK ambient label \"" SMACK_RUN_LABEL "\": %m");
+         r = write_string_file("/sys/fs/smackfs/netlabel",
+-                              "0.0.0.0/0 " SMACK_RUN_LABEL, WRITE_STRING_FILE_DISABLE_BUFFER);
++                              "0.0.0.0/0 " SMACK_RUN_LABEL, 0);
+         if (r < 0)
+                 log_warning_errno(r, "Failed to set SMACK netlabel rule \"0.0.0.0/0 " SMACK_RUN_LABEL "\": %m");
+-        r = write_string_file("/sys/fs/smackfs/netlabel", "127.0.0.1 -CIPSO", WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file("/sys/fs/smackfs/netlabel", "127.0.0.1 -CIPSO", 0);
+         if (r < 0)
+                 log_warning_errno(r, "Failed to set SMACK netlabel rule \"127.0.0.1 -CIPSO\": %m");
+ #endif
+diff --git a/src/home/homework.c b/src/home/homework.c
+index 066483e342..5f92dd7064 100644
+--- a/src/home/homework.c
++++ b/src/home/homework.c
+@@ -278,7 +278,7 @@ static void drop_caches_now(void) {
+          * for details. We write "2" into /proc/sys/vm/drop_caches to ensure dentries/inodes are flushed, but
+          * not more. */
+ 
+-        r = write_string_file("/proc/sys/vm/drop_caches", "2\n", WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file("/proc/sys/vm/drop_caches", "2\n", 0);
+         if (r < 0)
+                 log_warning_errno(r, "Failed to drop caches, ignoring: %m");
+         else
+diff --git a/src/libsystemd/sd-device/sd-device.c b/src/libsystemd/sd-device/sd-device.c
+index 2fbc619a34..09d9591e37 100644
+--- a/src/libsystemd/sd-device/sd-device.c
++++ b/src/libsystemd/sd-device/sd-device.c
+@@ -2516,7 +2516,7 @@ _public_ int sd_device_set_sysattr_value(sd_device *device, const char *sysattr,
+         if (!value)
+                 return -ENOMEM;
+ 
+-        r = write_string_file(path, value, WRITE_STRING_FILE_DISABLE_BUFFER | WRITE_STRING_FILE_NOFOLLOW);
++        r = write_string_file(path, value, 0 | WRITE_STRING_FILE_NOFOLLOW);
+         if (r < 0) {
+                 /* On failure, clear cache entry, as we do not know how it fails. */
+                 device_remove_cached_sysattr_value(device, sysattr);
+diff --git a/src/nspawn/nspawn-cgroup.c b/src/nspawn/nspawn-cgroup.c
+index a5002437c6..b12e6cd9c9 100644
+--- a/src/nspawn/nspawn-cgroup.c
++++ b/src/nspawn/nspawn-cgroup.c
+@@ -124,7 +124,7 @@ int sync_cgroup(pid_t pid, CGroupUnified unified_requested, uid_t uid_shift) {
+         fn = strjoina(tree, cgroup, "/cgroup.procs");
+ 
+         sprintf(pid_string, PID_FMT, pid);
+-        r = write_string_file(fn, pid_string, WRITE_STRING_FILE_DISABLE_BUFFER|WRITE_STRING_FILE_MKDIR_0755);
++        r = write_string_file(fn, pid_string, WRITE_STRING_FILE_MKDIR_0755);
+         if (r < 0) {
+                 log_error_errno(r, "Failed to move process: %m");
+                 goto finish;
+diff --git a/src/nspawn/nspawn.c b/src/nspawn/nspawn.c
+index 6ab604d3dc..bbec6b686c 100644
+--- a/src/nspawn/nspawn.c
++++ b/src/nspawn/nspawn.c
+@@ -2688,7 +2688,7 @@ static int reset_audit_loginuid(void) {
+         if (streq(p, "4294967295"))
+                 return 0;
+ 
+-        r = write_string_file("/proc/self/loginuid", "4294967295", WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file("/proc/self/loginuid", "4294967295", 0);
+         if (r < 0) {
+                 log_error_errno(r,
+                                 "Failed to reset audit login UID. This probably means that your kernel is too\n"
+@@ -4141,7 +4141,7 @@ static int setup_uid_map(
+                 return log_oom();
+ 
+         xsprintf(uid_map, "/proc/" PID_FMT "/uid_map", pid);
+-        r = write_string_file(uid_map, s, WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file(uid_map, s, 0);
+         if (r < 0)
+                 return log_error_errno(r, "Failed to write UID map: %m");
+ 
+@@ -4151,7 +4151,7 @@ static int setup_uid_map(
+                 return log_oom();
+ 
+         xsprintf(uid_map, "/proc/" PID_FMT "/gid_map", pid);
+-        r = write_string_file(uid_map, s, WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file(uid_map, s, 0);
+         if (r < 0)
+                 return log_error_errno(r, "Failed to write GID map: %m");
+ 
+diff --git a/src/shared/binfmt-util.c b/src/shared/binfmt-util.c
+index a26175474b..1413a9c72c 100644
+--- a/src/shared/binfmt-util.c
++++ b/src/shared/binfmt-util.c
+@@ -46,7 +46,7 @@ int disable_binfmt(void) {
+                 return 0;
+         }
+ 
+-        r = write_string_file("/proc/sys/fs/binfmt_misc/status", "-1", WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file("/proc/sys/fs/binfmt_misc/status", "-1", 0);
+         if (r < 0)
+                 return log_warning_errno(r, "Failed to unregister binfmt_misc entries: %m");
+ 
+diff --git a/src/shared/cgroup-setup.c b/src/shared/cgroup-setup.c
+index 934a16eaf3..c921ced861 100644
+--- a/src/shared/cgroup-setup.c
++++ b/src/shared/cgroup-setup.c
+@@ -351,7 +351,7 @@ int cg_attach(const char *controller, const char *path, pid_t pid) {
+ 
+         xsprintf(c, PID_FMT "\n", pid);
+ 
+-        r = write_string_file(fs, c, WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file(fs, c, 0);
+         if (r == -EOPNOTSUPP && cg_is_threaded(path) > 0)
+                 /* When the threaded mode is used, we cannot read/write the file. Let's return recognizable error. */
+                 return -EUCLEAN;
+@@ -966,7 +966,7 @@ int cg_enable_everywhere(
+                                         return log_debug_errno(errno, "Failed to open cgroup.subtree_control file of %s: %m", p);
+                         }
+ 
+-                        r = write_string_stream(f, s, WRITE_STRING_FILE_DISABLE_BUFFER);
++                        r = write_string_stream(f, s, 0);
+                         if (r < 0) {
+                                 log_debug_errno(r, "Failed to %s controller %s for %s (%s): %m",
+                                                 FLAGS_SET(mask, bit) ? "enable" : "disable", n, p, fs);
+diff --git a/src/shared/coredump-util.c b/src/shared/coredump-util.c
+index 805503f366..01a7ccb291 100644
+--- a/src/shared/coredump-util.c
++++ b/src/shared/coredump-util.c
+@@ -163,7 +163,7 @@ int set_coredump_filter(uint64_t value) {
+         xsprintf(t, "0x%"PRIx64, value);
+ 
+         return write_string_file("/proc/self/coredump_filter", t,
+-                                 WRITE_STRING_FILE_VERIFY_ON_FAILURE|WRITE_STRING_FILE_DISABLE_BUFFER);
++                                 0);
+ }
+ 
+ /* Turn off core dumps but only if we're running outside of a container. */
+@@ -173,7 +173,7 @@ void disable_coredumps(void) {
+         if (detect_container() > 0)
+                 return;
+ 
+-        r = write_string_file("/proc/sys/kernel/core_pattern", "|/bin/false", WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file("/proc/sys/kernel/core_pattern", "|/bin/false", 0);
+         if (r < 0)
+                 log_debug_errno(r, "Failed to turn off coredumps, ignoring: %m");
+ }
+diff --git a/src/shared/hibernate-util.c b/src/shared/hibernate-util.c
+index 3eb13d48f6..d09b901be1 100644
+--- a/src/shared/hibernate-util.c
++++ b/src/shared/hibernate-util.c
+@@ -481,7 +481,7 @@ int write_resume_config(dev_t devno, uint64_t offset, const char *device) {
+ 
+         /* We write the offset first since it's safer. Note that this file is only available in 4.17+, so
+          * fail gracefully if it doesn't exist and we're only overwriting it with 0. */
+-        r = write_string_file("/sys/power/resume_offset", offset_str, WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file("/sys/power/resume_offset", offset_str, 0);
+         if (r == -ENOENT) {
+                 if (offset != 0)
+                         return log_error_errno(SYNTHETIC_ERRNO(EOPNOTSUPP),
+@@ -497,7 +497,7 @@ int write_resume_config(dev_t devno, uint64_t offset, const char *device) {
+                 log_debug("Wrote resume_offset=%s for device '%s' to /sys/power/resume_offset.",
+                           offset_str, device);
+ 
+-        r = write_string_file("/sys/power/resume", devno_str, WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file("/sys/power/resume", devno_str, 0);
+         if (r < 0)
+                 return log_error_errno(r,
+                                        "Failed to write device '%s' (%s) to /sys/power/resume: %m",
+diff --git a/src/shared/smack-util.c b/src/shared/smack-util.c
+index 1f88e724d0..feb18b320a 100644
+--- a/src/shared/smack-util.c
++++ b/src/shared/smack-util.c
+@@ -113,7 +113,7 @@ int mac_smack_apply_pid(pid_t pid, const char *label) {
+                 return 0;
+ 
+         p = procfs_file_alloca(pid, "attr/current");
+-        r = write_string_file(p, label, WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file(p, label, 0);
+         if (r < 0)
+                 return r;
+ 
+diff --git a/src/shared/watchdog.c b/src/shared/watchdog.c
+index 4c1a968718..6faf6806a5 100644
+--- a/src/shared/watchdog.c
++++ b/src/shared/watchdog.c
+@@ -93,7 +93,7 @@ static int set_pretimeout_governor(const char *governor) {
+ 
+         r = write_string_file(sys_fn,
+                               governor,
+-                              WRITE_STRING_FILE_DISABLE_BUFFER | WRITE_STRING_FILE_VERIFY_ON_FAILURE | WRITE_STRING_FILE_VERIFY_IGNORE_NEWLINE);
++                              WRITE_STRING_FILE_VERIFY_ON_FAILURE | WRITE_STRING_FILE_VERIFY_IGNORE_NEWLINE);
+         if (r < 0)
+                 return log_error_errno(r, "Failed to set pretimeout_governor to '%s': %m", governor);
+ 
+diff --git a/src/sleep/sleep.c b/src/sleep/sleep.c
+index 21af3e9e52..6d4b84b5d5 100644
+--- a/src/sleep/sleep.c
++++ b/src/sleep/sleep.c
+@@ -137,7 +137,7 @@ static int write_state(int fd, char * const *states) {
+                 if (k < 0)
+                         return RET_GATHER(r, k);
+ 
+-                k = write_string_stream(f, *state, WRITE_STRING_FILE_DISABLE_BUFFER);
++                k = write_string_stream(f, *state, 0);
+                 if (k >= 0) {
+                         log_debug("Using sleep state '%s'.", *state);
+                         return 0;
+@@ -155,7 +155,7 @@ static int write_mode(char * const *modes) {
+         STRV_FOREACH(mode, modes) {
+                 int k;
+ 
+-                k = write_string_file("/sys/power/disk", *mode, WRITE_STRING_FILE_DISABLE_BUFFER);
++                k = write_string_file("/sys/power/disk", *mode, 0);
+                 if (k >= 0) {
+                         log_debug("Using sleep disk mode '%s'.", *mode);
+                         return 0;
+diff --git a/src/storagetm/storagetm.c b/src/storagetm/storagetm.c
+index ae63baaf79..82eeca479a 100644
+--- a/src/storagetm/storagetm.c
++++ b/src/storagetm/storagetm.c
+@@ -186,7 +186,7 @@ static int nvme_subsystem_unlink(NvmeSubsystem *s) {
+                                         if (!enable_fn)
+                                                 return log_oom();
+ 
+-                                        r = write_string_file_at(namespaces_fd, enable_fn, "0", WRITE_STRING_FILE_DISABLE_BUFFER);
++                                        r = write_string_file_at(namespaces_fd, enable_fn, "0", 0);
+                                         if (r < 0)
+                                                 log_warning_errno(r, "Failed to disable namespace '%s' of NVME subsystem '%s', ignoring: %m", e->d_name, s->name);
+ 
+@@ -254,7 +254,7 @@ static int nvme_subsystem_write_metadata(int subsystem_fd, sd_device *device) {
+                 _cleanup_free_ char *truncated = strndup(w, 40); /* kernel refuses more than 40 chars (as per nvme spec) */
+ 
+                 /* The default string stored in 'attr_model' is "Linux" btw. */
+-                r = write_string_file_at(subsystem_fd, "attr_model", truncated, WRITE_STRING_FILE_DISABLE_BUFFER);
++                r = write_string_file_at(subsystem_fd, "attr_model", truncated, 0);
+                 if (r < 0)
+                         log_warning_errno(r, "Failed to set model of subsystem to '%s', ignoring: %m", w);
+         }
+@@ -268,7 +268,7 @@ static int nvme_subsystem_write_metadata(int subsystem_fd, sd_device *device) {
+                         return log_oom();
+ 
+                  /* The default string stored in 'attr_firmware' is `uname -r` btw, but truncated to 8 chars. */
+-                r = write_string_file_at(subsystem_fd, "attr_firmware", truncated, WRITE_STRING_FILE_DISABLE_BUFFER);
++                r = write_string_file_at(subsystem_fd, "attr_firmware", truncated, 0);
+                 if (r < 0)
+                         log_warning_errno(r, "Failed to set model of subsystem to '%s', ignoring: %m", truncated);
+         }
+@@ -295,7 +295,7 @@ static int nvme_subsystem_write_metadata(int subsystem_fd, sd_device *device) {
+                 if (!truncated)
+                         return log_oom();
+ 
+-                r = write_string_file_at(subsystem_fd, "attr_serial", truncated, WRITE_STRING_FILE_DISABLE_BUFFER);
++                r = write_string_file_at(subsystem_fd, "attr_serial", truncated, 0);
+                 if (r < 0)
+                         log_warning_errno(r, "Failed to set serial of subsystem to '%s', ignoring: %m", truncated);
+         }
+@@ -345,7 +345,7 @@ static int nvme_namespace_write_metadata(int namespace_fd, sd_device *device, co
+                 id = id128_digest(j, l);
+         }
+ 
+-        r = write_string_file_at(namespace_fd, "device_uuid", SD_ID128_TO_UUID_STRING(id), WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file_at(namespace_fd, "device_uuid", SD_ID128_TO_UUID_STRING(id), 0);
+         if (r < 0)
+                 log_warning_errno(r, "Failed to set uuid of namespace to '%s', ignoring: %m", SD_ID128_TO_UUID_STRING(id));
+ 
+@@ -408,7 +408,7 @@ static int nvme_subsystem_add(const char *node, int consumed_fd, sd_device *devi
+         if (subsystem_fd < 0)
+                 return log_error_errno(subsystem_fd, "Failed to create NVME subsystem '%s': %m", j);
+ 
+-        r = write_string_file_at(subsystem_fd, "attr_allow_any_host", "1", WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file_at(subsystem_fd, "attr_allow_any_host", "1", 0);
+         if (r < 0)
+                 return log_error_errno(r, "Failed to set 'attr_allow_any_host' flag: %m");
+ 
+@@ -423,11 +423,11 @@ static int nvme_subsystem_add(const char *node, int consumed_fd, sd_device *devi
+ 
+         /* We use /proc/$PID/fd/$FD rather than /proc/self/fd/$FD, because this string is visible to others
+          * via configfs, and by including the PID it's clear to who the stuff belongs. */
+-        r = write_string_file_at(namespace_fd, "device_path", FORMAT_PROC_PID_FD_PATH(0, fd), WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file_at(namespace_fd, "device_path", FORMAT_PROC_PID_FD_PATH(0, fd), 0);
+         if (r < 0)
+                 return log_error_errno(r, "Failed to write 'device_path' attribute: %m");
+ 
+-        r = write_string_file_at(namespace_fd, "enable", "1", WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file_at(namespace_fd, "enable", "1", 0);
+         if (r < 0)
+                 return log_error_errno(r, "Failed to write 'enable' attribute: %m");
+ 
+@@ -557,19 +557,19 @@ static int nvme_port_add_portnr(
+                 return 0;
+         }
+ 
+-        r = write_string_file_at(port_fd, "addr_adrfam", af_to_ipv4_ipv6(ip_family), WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file_at(port_fd, "addr_adrfam", af_to_ipv4_ipv6(ip_family), 0);
+         if (r < 0)
+                 return log_error_errno(r, "Failed to set address family on NVME port %" PRIu16 ": %m", portnr);
+ 
+-        r = write_string_file_at(port_fd, "addr_trtype", "tcp", WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file_at(port_fd, "addr_trtype", "tcp", 0);
+         if (r < 0)
+                 return log_error_errno(r, "Failed to set transport type on NVME port %" PRIu16 ": %m", portnr);
+ 
+-        r = write_string_file_at(port_fd, "addr_trsvcid", fname, WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file_at(port_fd, "addr_trsvcid", fname, 0);
+         if (r < 0)
+                 return log_error_errno(r, "Failed to set IP port on NVME port %" PRIu16 ": %m", portnr);
+ 
+-        r = write_string_file_at(port_fd, "addr_traddr", ip_family == AF_INET6 ? "::" : "0.0.0.0", WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file_at(port_fd, "addr_traddr", ip_family == AF_INET6 ? "::" : "0.0.0.0", 0);
+         if (r < 0)
+                 return log_error_errno(r, "Failed to set IP address on NVME port %" PRIu16 ": %m", portnr);
+ 
+diff --git a/src/udev/udev-rules.c b/src/udev/udev-rules.c
+index febe345b4c..a90b610ba1 100644
+--- a/src/udev/udev-rules.c
++++ b/src/udev/udev-rules.c
+@@ -2711,7 +2711,6 @@ static int udev_rule_apply_token_to_event(
+                 log_event_debug(dev, token, "ATTR '%s' writing '%s'", buf, value);
+                 r = write_string_file(buf, value,
+                                       WRITE_STRING_FILE_VERIFY_ON_FAILURE |
+-                                      WRITE_STRING_FILE_DISABLE_BUFFER |
+                                       WRITE_STRING_FILE_AVOID_NEWLINE |
+                                       WRITE_STRING_FILE_VERIFY_IGNORE_NEWLINE);
+                 if (r < 0)
+diff --git a/src/vconsole/vconsole-setup.c b/src/vconsole/vconsole-setup.c
+index 4d82c65f0a..3a3d861b83 100644
+--- a/src/vconsole/vconsole-setup.c
++++ b/src/vconsole/vconsole-setup.c
+@@ -261,7 +261,7 @@ static int toggle_utf8_vc(const char *name, int fd, bool utf8) {
+ static int toggle_utf8_sysfs(bool utf8) {
+         int r;
+ 
+-        r = write_string_file("/sys/module/vt/parameters/default_utf8", one_zero(utf8), WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file("/sys/module/vt/parameters/default_utf8", one_zero(utf8), 0);
+         if (r < 0)
+                 return log_warning_errno(r, "Failed to %s sysfs UTF-8 flag: %m", enable_disable(utf8));
+ 
+-- 
+2.34.1
+

--- a/recipes-backports/sdbus-c++/sdbus-c++-libsystemd/0013-Handle-__cpu_mask-usage.patch
+++ b/recipes-backports/sdbus-c++/sdbus-c++-libsystemd/0013-Handle-__cpu_mask-usage.patch
@@ -1,0 +1,60 @@
+From 2f90f8463423cfbb7e83fcef42f1071018c3b56e Mon Sep 17 00:00:00 2001
+From: Scott Murray <scott.murray@konsulko.com>
+Date: Fri, 13 Sep 2019 19:26:27 -0400
+Subject: [PATCH 13/22] Handle __cpu_mask usage
+
+Fixes errors:
+
+src/test/test-cpu-set-util.c:18:54: error: '__cpu_mask' undeclared (first use in this function)
+src/test/test-sizeof.c:73:14: error: '__cpu_mask' undeclared (first use in this function)
+
+__cpu_mask is an internal type of glibc's cpu_set implementation, not
+part of the POSIX definition, which is problematic when building with
+musl, which does not define a matching type.  From inspection of musl's
+sched.h, however, it is clear that the corresponding type would be
+unsigned long, which does match glibc's actual __CPU_MASK_TYPE.  So,
+add a typedef to cpu-set-util.h defining __cpu_mask appropriately.
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Scott Murray <scott.murray@konsulko.com>
+---
+ src/shared/cpu-set-util.h | 2 ++
+ src/test/test-sizeof.c    | 2 +-
+ 2 files changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/src/shared/cpu-set-util.h b/src/shared/cpu-set-util.h
+index 3c63a58826..4c2d4347fc 100644
+--- a/src/shared/cpu-set-util.h
++++ b/src/shared/cpu-set-util.h
+@@ -6,6 +6,8 @@
+ #include "macro.h"
+ #include "missing_syscall.h"
+ 
++typedef unsigned long __cpu_mask;
++
+ /* This wraps the libc interface with a variable to keep the allocated size. */
+ typedef struct CPUSet {
+         cpu_set_t *set;
+diff --git a/src/test/test-sizeof.c b/src/test/test-sizeof.c
+index ea0c58770e..b65c0bd370 100644
+--- a/src/test/test-sizeof.c
++++ b/src/test/test-sizeof.c
+@@ -1,6 +1,5 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+ 
+-#include <sched.h>
+ #include <stdio.h>
+ #include <string.h>
+ #include <sys/resource.h>
+@@ -12,6 +11,7 @@
+ #include <float.h>
+ 
+ #include "time-util.h"
++#include "cpu-set-util.h"
+ 
+ /* Print information about various types. Useful when diagnosing
+  * gcc diagnostics on an unfamiliar architecture. */
+-- 
+2.34.1
+

--- a/recipes-backports/sdbus-c++/sdbus-c++-libsystemd/0014-Handle-missing-gshadow.patch
+++ b/recipes-backports/sdbus-c++/sdbus-c++-libsystemd/0014-Handle-missing-gshadow.patch
@@ -1,0 +1,173 @@
+From b7c827bb44edbb6251c9fcdb80aa03982c0e7bf3 Mon Sep 17 00:00:00 2001
+From: Alex Kiernan <alex.kiernan@gmail.com>
+Date: Tue, 10 Mar 2020 11:05:20 +0000
+Subject: [PATCH 14/22] Handle missing gshadow
+
+gshadow usage is now present in the userdb code. Mask all uses of it to
+allow compilation on musl
+
+Upstream-Status: Inappropriate [musl specific]
+Signed-off-by: Alex Kiernan <alex.kiernan@gmail.com>
+[Rebased for v247]
+Signed-off-by: Luca Boccassi <luca.boccassi@microsoft.com>
+---
+ src/shared/user-record-nss.c | 20 ++++++++++++++++++++
+ src/shared/user-record-nss.h |  4 ++++
+ src/shared/userdb.c          |  7 ++++++-
+ 3 files changed, 30 insertions(+), 1 deletion(-)
+
+diff --git a/src/shared/user-record-nss.c b/src/shared/user-record-nss.c
+index 414a49331b..1a4e1b628c 100644
+--- a/src/shared/user-record-nss.c
++++ b/src/shared/user-record-nss.c
+@@ -329,8 +329,10 @@ int nss_group_to_group_record(
+         if (isempty(grp->gr_name))
+                 return -EINVAL;
+ 
++#if ENABLE_GSHADOW
+         if (sgrp && !streq_ptr(sgrp->sg_namp, grp->gr_name))
+                 return -EINVAL;
++#endif
+ 
+         g = group_record_new();
+         if (!g)
+@@ -346,6 +348,7 @@ int nss_group_to_group_record(
+ 
+         g->gid = grp->gr_gid;
+ 
++#if ENABLE_GSHADOW
+         if (sgrp) {
+                 if (looks_like_hashed_password(utf8_only(sgrp->sg_passwd))) {
+                         g->hashed_password = strv_new(sgrp->sg_passwd);
+@@ -361,6 +364,7 @@ int nss_group_to_group_record(
+                 if (r < 0)
+                         return r;
+         }
++#endif
+ 
+         r = json_build(&g->json, JSON_BUILD_OBJECT(
+                                        JSON_BUILD_PAIR("groupName", JSON_BUILD_STRING(g->group_name)),
+@@ -387,6 +391,7 @@ int nss_sgrp_for_group(const struct group *grp, struct sgrp *ret_sgrp, char **re
+         assert(ret_sgrp);
+         assert(ret_buffer);
+ 
++#if ENABLE_GSHADOW
+         for (;;) {
+                 _cleanup_free_ char *buf = NULL;
+                 struct sgrp sgrp, *result;
+@@ -415,6 +420,9 @@ int nss_sgrp_for_group(const struct group *grp, struct sgrp *ret_sgrp, char **re
+                 buflen *= 2;
+                 buf = mfree(buf);
+         }
++#else
++        return -ESRCH;
++#endif
+ }
+ 
+ int nss_group_record_by_name(
+@@ -426,7 +434,9 @@ int nss_group_record_by_name(
+         struct group grp, *result;
+         bool incomplete = false;
+         size_t buflen = 4096;
++#if ENABLE_GSHADOW
+         struct sgrp sgrp, *sresult = NULL;
++#endif
+         int r;
+ 
+         assert(name);
+@@ -455,6 +465,7 @@ int nss_group_record_by_name(
+                 buf = mfree(buf);
+         }
+ 
++#if ENABLE_GSHADOW
+         if (with_shadow) {
+                 r = nss_sgrp_for_group(result, &sgrp, &sbuf);
+                 if (r < 0) {
+@@ -466,6 +477,9 @@ int nss_group_record_by_name(
+                 incomplete = true;
+ 
+         r = nss_group_to_group_record(result, sresult, ret);
++#else
++        r = nss_group_to_group_record(result, NULL, ret);
++#endif
+         if (r < 0)
+                 return r;
+ 
+@@ -483,7 +497,9 @@ int nss_group_record_by_gid(
+         struct group grp, *result;
+         bool incomplete = false;
+         size_t buflen = 4096;
++#if ENABLE_GSHADOW
+         struct sgrp sgrp, *sresult = NULL;
++#endif
+         int r;
+ 
+         for (;;) {
+@@ -509,6 +525,7 @@ int nss_group_record_by_gid(
+                 buf = mfree(buf);
+         }
+ 
++#if ENABLE_GSHADOW
+         if (with_shadow) {
+                 r = nss_sgrp_for_group(result, &sgrp, &sbuf);
+                 if (r < 0) {
+@@ -520,6 +537,9 @@ int nss_group_record_by_gid(
+                 incomplete = true;
+ 
+         r = nss_group_to_group_record(result, sresult, ret);
++#else
++        r = nss_group_to_group_record(result, NULL, ret);
++#endif
+         if (r < 0)
+                 return r;
+ 
+diff --git a/src/shared/user-record-nss.h b/src/shared/user-record-nss.h
+index 22ab04d6ee..4e52e7a911 100644
+--- a/src/shared/user-record-nss.h
++++ b/src/shared/user-record-nss.h
+@@ -2,7 +2,11 @@
+ #pragma once
+ 
+ #include <grp.h>
++#if ENABLE_GSHADOW
+ #include <gshadow.h>
++#else
++struct sgrp;
++#endif
+ #include <pwd.h>
+ #include <shadow.h>
+ 
+diff --git a/src/shared/userdb.c b/src/shared/userdb.c
+index f60d48ace4..e878199a28 100644
+--- a/src/shared/userdb.c
++++ b/src/shared/userdb.c
+@@ -1038,13 +1038,15 @@ int groupdb_iterator_get(UserDBIterator *iterator, GroupRecord **ret) {
+                 if (gr) {
+                         _cleanup_free_ char *buffer = NULL;
+                         bool incomplete = false;
++#if ENABLE_GSHADOW
+                         struct sgrp sgrp;
+-
++#endif
+                         if (streq_ptr(gr->gr_name, "root"))
+                                 iterator->synthesize_root = false;
+                         if (gr->gr_gid == GID_NOBODY)
+                                 iterator->synthesize_nobody = false;
+ 
++#if ENABLE_GSHADOW
+                         if (!FLAGS_SET(iterator->flags, USERDB_SUPPRESS_SHADOW)) {
+                                 r = nss_sgrp_for_group(gr, &sgrp, &buffer);
+                                 if (r < 0) {
+@@ -1057,6 +1059,9 @@ int groupdb_iterator_get(UserDBIterator *iterator, GroupRecord **ret) {
+                         }
+ 
+                         r = nss_group_to_group_record(gr, r >= 0 ? &sgrp : NULL, ret);
++#else
++                        r = nss_group_to_group_record(gr, NULL, ret);
++#endif
+                         if (r < 0)
+                                 return r;
+ 
+-- 
+2.34.1
+

--- a/recipes-backports/sdbus-c++/sdbus-c++-libsystemd/0015-missing_syscall.h-Define-MIPS-ABI-defines-for-musl.patch
+++ b/recipes-backports/sdbus-c++/sdbus-c++-libsystemd/0015-missing_syscall.h-Define-MIPS-ABI-defines-for-musl.patch
@@ -1,0 +1,49 @@
+From 3dc9d9d410bcce54fddfd94f43f7f77f3aa8e281 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Mon, 12 Apr 2021 23:44:53 -0700
+Subject: [PATCH 15/22] missing_syscall.h: Define MIPS ABI defines for musl
+
+musl does not define _MIPS_SIM_ABI32, _MIPS_SIM_NABI32, _MIPS_SIM_ABI64
+unlike glibc where these are provided by libc headers, therefore define
+them here in case they are undefined
+
+Upstream-Status: Pending
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ src/basic/missing_syscall.h  | 6 ++++++
+ src/shared/base-filesystem.c | 1 +
+ 2 files changed, 7 insertions(+)
+
+diff --git a/src/basic/missing_syscall.h b/src/basic/missing_syscall.h
+index d795efd8f2..d6729d3c1d 100644
+--- a/src/basic/missing_syscall.h
++++ b/src/basic/missing_syscall.h
+@@ -20,6 +20,12 @@
+ #include <asm/sgidefs.h>
+ #endif
+ 
++#ifndef _MIPS_SIM_ABI32
++#define _MIPS_SIM_ABI32	1
++#define _MIPS_SIM_NABI32 2
++#define _MIPS_SIM_ABI64	3
++#endif
++
+ #include "macro.h"
+ #include "missing_keyctl.h"
+ #include "missing_stat.h"
+diff --git a/src/shared/base-filesystem.c b/src/shared/base-filesystem.c
+index 7ae921a113..0ef9d1fd39 100644
+--- a/src/shared/base-filesystem.c
++++ b/src/shared/base-filesystem.c
+@@ -20,6 +20,7 @@
+ #include "string-util.h"
+ #include "umask-util.h"
+ #include "user-util.h"
++#include "missing_syscall.h"
+ 
+ typedef struct BaseFilesystem {
+         const char *dir;      /* directory or symlink to create */
+-- 
+2.34.1
+

--- a/recipes-backports/sdbus-c++/sdbus-c++-libsystemd/0016-pass-correct-parameters-to-getdents64.patch
+++ b/recipes-backports/sdbus-c++/sdbus-c++-libsystemd/0016-pass-correct-parameters-to-getdents64.patch
@@ -1,0 +1,37 @@
+From 0994b59dba9f248ad31cb7087046dc00b72cb4ea Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Fri, 21 Jan 2022 15:15:11 -0800
+Subject: [PATCH 16/22] pass correct parameters to getdents64
+
+Fixes
+../git/src/basic/recurse-dir.c:57:40: error: incompatible pointer types passing 'uint8_t *' (aka 'unsigned char *') to parameter of type 'struct dirent *' [-Werror,-Wincompatible-pointer-types]
+                n = getdents64(dir_fd, (uint8_t*) de->buffer + de->buffer_size, bs - de->buffer_size);
+                                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+../git/src/basic/stat-util.c:102:28: error: incompatible pointer types passing 'union (unnamed union at ../git/src/basic/stat-util.c:78:9) *' to parameter of type 'struct dirent *' [-Werror,-Wincompatible-pointer-types]
+        n = getdents64(fd, &buffer, sizeof(buffer));
+                           ^~~~~~~
+
+Upstream-Status: Inappropriate [musl specific]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+Signed-off-by: Jiaqing Zhao <jiaqing.zhao@linux.intel.com>
+---
+ src/basic/recurse-dir.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/basic/recurse-dir.c b/src/basic/recurse-dir.c
+index 5e98b7a5d8..aef065047b 100644
+--- a/src/basic/recurse-dir.c
++++ b/src/basic/recurse-dir.c
+@@ -55,7 +55,7 @@ int readdir_all(int dir_fd,
+                 bs = MIN(MALLOC_SIZEOF_SAFE(de) - offsetof(DirectoryEntries, buffer), (size_t) SSIZE_MAX);
+                 assert(bs > de->buffer_size);
+ 
+-                n = getdents64(dir_fd, (uint8_t*) de->buffer + de->buffer_size, bs - de->buffer_size);
++                n = getdents64(dir_fd, (struct dirent*)((uint8_t*) de->buffer + de->buffer_size), bs - de->buffer_size);
+                 if (n < 0)
+                         return -errno;
+                 if (n == 0)
+-- 
+2.34.1
+

--- a/recipes-backports/sdbus-c++/sdbus-c++-libsystemd/0017-Adjust-for-musl-headers.patch
+++ b/recipes-backports/sdbus-c++/sdbus-c++-libsystemd/0017-Adjust-for-musl-headers.patch
@@ -1,0 +1,572 @@
+From 3c094d443ca30f19114392fd8ef274af6eabc12d Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Fri, 21 Jan 2022 22:19:37 -0800
+Subject: [PATCH 17/22] Adjust for musl headers
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+
+[Rebased for v255.1]
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+---
+ src/libsystemd-network/sd-dhcp6-client.c      | 2 +-
+ src/network/netdev/bareudp.c                  | 2 +-
+ src/network/netdev/batadv.c                   | 2 +-
+ src/network/netdev/bond.c                     | 2 +-
+ src/network/netdev/bridge.c                   | 2 +-
+ src/network/netdev/dummy.c                    | 2 +-
+ src/network/netdev/geneve.c                   | 2 +-
+ src/network/netdev/ifb.c                      | 2 +-
+ src/network/netdev/ipoib.c                    | 2 +-
+ src/network/netdev/ipvlan.c                   | 2 +-
+ src/network/netdev/macsec.c                   | 2 +-
+ src/network/netdev/macvlan.c                  | 2 +-
+ src/network/netdev/netdev.c                   | 2 +-
+ src/network/netdev/netdevsim.c                | 2 +-
+ src/network/netdev/nlmon.c                    | 2 +-
+ src/network/netdev/tunnel.c                   | 2 +-
+ src/network/netdev/vcan.c                     | 2 +-
+ src/network/netdev/veth.c                     | 2 +-
+ src/network/netdev/vlan.c                     | 2 +-
+ src/network/netdev/vrf.c                      | 2 +-
+ src/network/netdev/vxcan.c                    | 2 +-
+ src/network/netdev/vxlan.c                    | 2 +-
+ src/network/netdev/wireguard.c                | 2 +-
+ src/network/netdev/xfrm.c                     | 2 +-
+ src/network/networkd-bridge-mdb.c             | 4 ++--
+ src/network/networkd-dhcp-common.c            | 3 ++-
+ src/network/networkd-dhcp-prefix-delegation.c | 3 ++-
+ src/network/networkd-dhcp-server.c            | 2 +-
+ src/network/networkd-dhcp4.c                  | 2 +-
+ src/network/networkd-ipv6ll.c                 | 2 +-
+ src/network/networkd-link.c                   | 2 +-
+ src/network/networkd-ndisc.c                  | 2 +-
+ src/network/networkd-route.c                  | 8 ++++----
+ src/network/networkd-setlink.c                | 2 +-
+ src/network/networkd-sysctl.c                 | 2 +-
+ src/shared/linux/ethtool.h                    | 3 ++-
+ src/shared/netif-util.c                       | 2 +-
+ src/udev/udev-builtin-net_id.c                | 2 +-
+ 38 files changed, 45 insertions(+), 42 deletions(-)
+
+diff --git a/src/libsystemd-network/sd-dhcp6-client.c b/src/libsystemd-network/sd-dhcp6-client.c
+index c20367dfc9..b8d4cd8c2a 100644
+--- a/src/libsystemd-network/sd-dhcp6-client.c
++++ b/src/libsystemd-network/sd-dhcp6-client.c
+@@ -5,7 +5,7 @@
+ 
+ #include <errno.h>
+ #include <sys/ioctl.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ #include <linux/if_infiniband.h>
+ 
+ #include "sd-dhcp6-client.h"
+diff --git a/src/network/netdev/bareudp.c b/src/network/netdev/bareudp.c
+index 1df886573b..c8b6714726 100644
+--- a/src/network/netdev/bareudp.c
++++ b/src/network/netdev/bareudp.c
+@@ -2,7 +2,7 @@
+  * Copyright © 2020 VMware, Inc. */
+ 
+ #include <netinet/in.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ 
+ #include "bareudp.h"
+ #include "netlink-util.h"
+diff --git a/src/network/netdev/batadv.c b/src/network/netdev/batadv.c
+index 26da0231d4..2e8002af8c 100644
+--- a/src/network/netdev/batadv.c
++++ b/src/network/netdev/batadv.c
+@@ -3,7 +3,7 @@
+ #include <inttypes.h>
+ #include <netinet/in.h>
+ #include <linux/genetlink.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ 
+ #include "batadv.h"
+ #include "fileio.h"
+diff --git a/src/network/netdev/bond.c b/src/network/netdev/bond.c
+index 4d75a0d6bf..985b3197e0 100644
+--- a/src/network/netdev/bond.c
++++ b/src/network/netdev/bond.c
+@@ -1,7 +1,7 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+ 
+ #include <netinet/in.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ 
+ #include "alloc-util.h"
+ #include "bond.h"
+diff --git a/src/network/netdev/bridge.c b/src/network/netdev/bridge.c
+index 3e394edadf..f12f667687 100644
+--- a/src/network/netdev/bridge.c
++++ b/src/network/netdev/bridge.c
+@@ -2,7 +2,7 @@
+ 
+ #include <net/if.h>
+ #include <netinet/in.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ #include <linux/if_bridge.h>
+ 
+ #include "bridge.h"
+diff --git a/src/network/netdev/dummy.c b/src/network/netdev/dummy.c
+index 00df1d2787..77b506b422 100644
+--- a/src/network/netdev/dummy.c
++++ b/src/network/netdev/dummy.c
+@@ -1,6 +1,6 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+ 
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ 
+ #include "dummy.h"
+ 
+diff --git a/src/network/netdev/geneve.c b/src/network/netdev/geneve.c
+index bc655ec7ff..a77e8e17e4 100644
+--- a/src/network/netdev/geneve.c
++++ b/src/network/netdev/geneve.c
+@@ -2,7 +2,7 @@
+ 
+ #include <net/if.h>
+ #include <netinet/in.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ 
+ #include "alloc-util.h"
+ #include "conf-parser.h"
+diff --git a/src/network/netdev/ifb.c b/src/network/netdev/ifb.c
+index d7ff44cb9e..e037629ae4 100644
+--- a/src/network/netdev/ifb.c
++++ b/src/network/netdev/ifb.c
+@@ -1,7 +1,7 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later
+  * Copyright © 2019 VMware, Inc. */
+ 
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ 
+ #include "ifb.h"
+ 
+diff --git a/src/network/netdev/ipoib.c b/src/network/netdev/ipoib.c
+index d5fe299b7b..c9c8002eac 100644
+--- a/src/network/netdev/ipoib.c
++++ b/src/network/netdev/ipoib.c
+@@ -1,6 +1,6 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+ 
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ #include <linux/if_link.h>
+ 
+ #include "ipoib.h"
+diff --git a/src/network/netdev/ipvlan.c b/src/network/netdev/ipvlan.c
+index 05d5d010f6..d440f49537 100644
+--- a/src/network/netdev/ipvlan.c
++++ b/src/network/netdev/ipvlan.c
+@@ -2,7 +2,7 @@
+ 
+ #include <net/if.h>
+ #include <netinet/in.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ 
+ #include "conf-parser.h"
+ #include "ipvlan.h"
+diff --git a/src/network/netdev/macsec.c b/src/network/netdev/macsec.c
+index 17d6acefb6..679d0984f9 100644
+--- a/src/network/netdev/macsec.c
++++ b/src/network/netdev/macsec.c
+@@ -1,7 +1,7 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+ 
+ #include <netinet/in.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ #include <linux/if_ether.h>
+ #include <linux/if_macsec.h>
+ #include <linux/genetlink.h>
+diff --git a/src/network/netdev/macvlan.c b/src/network/netdev/macvlan.c
+index 203807e3a5..8ab09a387e 100644
+--- a/src/network/netdev/macvlan.c
++++ b/src/network/netdev/macvlan.c
+@@ -2,7 +2,7 @@
+ 
+ #include <net/if.h>
+ #include <netinet/in.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ 
+ #include "conf-parser.h"
+ #include "macvlan.h"
+diff --git a/src/network/netdev/netdev.c b/src/network/netdev/netdev.c
+index 57127a861a..7f787d0b9f 100644
+--- a/src/network/netdev/netdev.c
++++ b/src/network/netdev/netdev.c
+@@ -2,7 +2,7 @@
+ 
+ #include <net/if.h>
+ #include <netinet/in.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ #include <unistd.h>
+ 
+ #include "alloc-util.h"
+diff --git a/src/network/netdev/netdevsim.c b/src/network/netdev/netdevsim.c
+index 15d5c132f9..a3ffa48b15 100644
+--- a/src/network/netdev/netdevsim.c
++++ b/src/network/netdev/netdevsim.c
+@@ -1,6 +1,6 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+ 
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ 
+ #include "netdevsim.h"
+ 
+diff --git a/src/network/netdev/nlmon.c b/src/network/netdev/nlmon.c
+index ff372092e6..eef66811f4 100644
+--- a/src/network/netdev/nlmon.c
++++ b/src/network/netdev/nlmon.c
+@@ -1,6 +1,6 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+ 
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ 
+ #include "nlmon.h"
+ 
+diff --git a/src/network/netdev/tunnel.c b/src/network/netdev/tunnel.c
+index db84e7cf6e..93d5642962 100644
+--- a/src/network/netdev/tunnel.c
++++ b/src/network/netdev/tunnel.c
+@@ -2,7 +2,7 @@
+ 
+ #include <netinet/in.h>
+ #include <linux/fou.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ #include <linux/if_tunnel.h>
+ #include <linux/ip.h>
+ #include <linux/ip6_tunnel.h>
+diff --git a/src/network/netdev/vcan.c b/src/network/netdev/vcan.c
+index 380547ee1e..137c1adf8a 100644
+--- a/src/network/netdev/vcan.c
++++ b/src/network/netdev/vcan.c
+@@ -1,6 +1,6 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+ 
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ 
+ #include "vcan.h"
+ 
+diff --git a/src/network/netdev/veth.c b/src/network/netdev/veth.c
+index e0f5b4ebb1..8a424ed03d 100644
+--- a/src/network/netdev/veth.c
++++ b/src/network/netdev/veth.c
+@@ -3,7 +3,7 @@
+ #include <errno.h>
+ #include <net/if.h>
+ #include <netinet/in.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ #include <linux/veth.h>
+ 
+ #include "netlink-util.h"
+diff --git a/src/network/netdev/vlan.c b/src/network/netdev/vlan.c
+index 2390206993..efec630e30 100644
+--- a/src/network/netdev/vlan.c
++++ b/src/network/netdev/vlan.c
+@@ -2,7 +2,7 @@
+ 
+ #include <errno.h>
+ #include <net/if.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ #include <linux/if_vlan.h>
+ 
+ #include "parse-util.h"
+diff --git a/src/network/netdev/vrf.c b/src/network/netdev/vrf.c
+index b75ec2bcc6..6aeeea640b 100644
+--- a/src/network/netdev/vrf.c
++++ b/src/network/netdev/vrf.c
+@@ -2,7 +2,7 @@
+ 
+ #include <net/if.h>
+ #include <netinet/in.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ 
+ #include "vrf.h"
+ 
+diff --git a/src/network/netdev/vxcan.c b/src/network/netdev/vxcan.c
+index c0343f45b6..f9e718f40b 100644
+--- a/src/network/netdev/vxcan.c
++++ b/src/network/netdev/vxcan.c
+@@ -1,7 +1,7 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+ 
+ #include <linux/can/vxcan.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ 
+ #include "vxcan.h"
+ 
+diff --git a/src/network/netdev/vxlan.c b/src/network/netdev/vxlan.c
+index b11fdbbd0d..a971a917f0 100644
+--- a/src/network/netdev/vxlan.c
++++ b/src/network/netdev/vxlan.c
+@@ -2,7 +2,7 @@
+ 
+ #include <net/if.h>
+ #include <netinet/in.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ 
+ #include "conf-parser.h"
+ #include "alloc-util.h"
+diff --git a/src/network/netdev/wireguard.c b/src/network/netdev/wireguard.c
+index 4c7d837c41..6df6dfb816 100644
+--- a/src/network/netdev/wireguard.c
++++ b/src/network/netdev/wireguard.c
+@@ -6,7 +6,7 @@
+ #include <sys/ioctl.h>
+ #include <net/if.h>
+ #include <netinet/in.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ #include <linux/ipv6_route.h>
+ 
+ #include "sd-resolve.h"
+diff --git a/src/network/netdev/xfrm.c b/src/network/netdev/xfrm.c
+index 905bfc0bdf..39e34dbb3b 100644
+--- a/src/network/netdev/xfrm.c
++++ b/src/network/netdev/xfrm.c
+@@ -1,6 +1,6 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+ 
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ 
+ #include "missing_network.h"
+ #include "xfrm.h"
+diff --git a/src/network/networkd-bridge-mdb.c b/src/network/networkd-bridge-mdb.c
+index bd1a9745dc..949d3da029 100644
+--- a/src/network/networkd-bridge-mdb.c
++++ b/src/network/networkd-bridge-mdb.c
+@@ -1,7 +1,5 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+ 
+-#include <net/if.h>
+-#include <linux/if_bridge.h>
+ 
+ #include "netlink-util.h"
+ #include "networkd-bridge-mdb.h"
+@@ -11,6 +9,8 @@
+ #include "networkd-queue.h"
+ #include "string-util.h"
+ #include "vlan-util.h"
++#include <net/if.h>
++#include <linux/if_bridge.h>
+ 
+ #define STATIC_BRIDGE_MDB_ENTRIES_PER_NETWORK_MAX 1024U
+ 
+diff --git a/src/network/networkd-dhcp-common.c b/src/network/networkd-dhcp-common.c
+index 080b15387c..efe8283957 100644
+--- a/src/network/networkd-dhcp-common.c
++++ b/src/network/networkd-dhcp-common.c
+@@ -1,7 +1,8 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+ 
+ #include <netinet/in.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
++#include <net/if.h>
+ 
+ #include "bus-error.h"
+ #include "bus-locator.h"
+diff --git a/src/network/networkd-dhcp-prefix-delegation.c b/src/network/networkd-dhcp-prefix-delegation.c
+index af2fe9efcd..511565700f 100644
+--- a/src/network/networkd-dhcp-prefix-delegation.c
++++ b/src/network/networkd-dhcp-prefix-delegation.c
+@@ -1,6 +1,5 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+ 
+-#include <linux/ipv6_route.h>
+ 
+ #include "dhcp6-lease-internal.h"
+ #include "hashmap.h"
+@@ -20,6 +19,8 @@
+ #include "strv.h"
+ #include "tunnel.h"
+ 
++#include <linux/ipv6_route.h>
++
+ bool link_dhcp_pd_is_enabled(Link *link) {
+         assert(link);
+ 
+diff --git a/src/network/networkd-dhcp-server.c b/src/network/networkd-dhcp-server.c
+index 607fe0053c..9ce4005874 100644
+--- a/src/network/networkd-dhcp-server.c
++++ b/src/network/networkd-dhcp-server.c
+@@ -1,7 +1,7 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+ 
+ #include <netinet/in.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ #include <linux/if.h>
+ 
+ #include "sd-dhcp-server.h"
+diff --git a/src/network/networkd-dhcp4.c b/src/network/networkd-dhcp4.c
+index efbae6d868..1ea2151d50 100644
+--- a/src/network/networkd-dhcp4.c
++++ b/src/network/networkd-dhcp4.c
+@@ -3,7 +3,7 @@
+ #include <netinet/in.h>
+ #include <netinet/ip.h>
+ #include <linux/if.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ 
+ #include "alloc-util.h"
+ #include "dhcp-client-internal.h"
+diff --git a/src/network/networkd-ipv6ll.c b/src/network/networkd-ipv6ll.c
+index 32229a3fc7..662a345d6e 100644
+--- a/src/network/networkd-ipv6ll.c
++++ b/src/network/networkd-ipv6ll.c
+@@ -1,7 +1,7 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+ 
+ #include <linux/if.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ 
+ #include "in-addr-util.h"
+ #include "networkd-address.h"
+diff --git a/src/network/networkd-link.c b/src/network/networkd-link.c
+index ee5f0f2c0a..ea5269a2de 100644
+--- a/src/network/networkd-link.c
++++ b/src/network/networkd-link.c
+@@ -3,7 +3,7 @@
+ #include <net/if.h>
+ #include <netinet/in.h>
+ #include <linux/if.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ #include <linux/if_link.h>
+ #include <linux/netdevice.h>
+ #include <sys/socket.h>
+diff --git a/src/network/networkd-ndisc.c b/src/network/networkd-ndisc.c
+index ab9eeb13a5..dd96fe7483 100644
+--- a/src/network/networkd-ndisc.c
++++ b/src/network/networkd-ndisc.c
+@@ -6,7 +6,7 @@
+ #include <arpa/inet.h>
+ #include <netinet/icmp6.h>
+ #include <linux/if.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ 
+ #include "sd-ndisc.h"
+ 
+diff --git a/src/network/networkd-route.c b/src/network/networkd-route.c
+index 7218d799fc..30d5574eae 100644
+--- a/src/network/networkd-route.c
++++ b/src/network/networkd-route.c
+@@ -1,9 +1,5 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+ 
+-#include <linux/icmpv6.h>
+-#include <linux/ipv6_route.h>
+-#include <linux/nexthop.h>
+-
+ #include "alloc-util.h"
+ #include "event-util.h"
+ #include "netlink-util.h"
+@@ -21,6 +17,10 @@
+ #include "vrf.h"
+ #include "wireguard.h"
+ 
++#include <linux/icmpv6.h>
++#include <linux/ipv6_route.h>
++#include <linux/nexthop.h>
++
+ int route_new(Route **ret) {
+         _cleanup_(route_freep) Route *route = NULL;
+ 
+diff --git a/src/network/networkd-setlink.c b/src/network/networkd-setlink.c
+index 2298f9ea3a..7d5f87de53 100644
+--- a/src/network/networkd-setlink.c
++++ b/src/network/networkd-setlink.c
+@@ -2,7 +2,7 @@
+ 
+ #include <netinet/in.h>
+ #include <linux/if.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ #include <linux/if_bridge.h>
+ 
+ #include "missing_network.h"
+diff --git a/src/network/networkd-sysctl.c b/src/network/networkd-sysctl.c
+index 2b226b2e2a..f12a474e2f 100644
+--- a/src/network/networkd-sysctl.c
++++ b/src/network/networkd-sysctl.c
+@@ -2,7 +2,7 @@
+ 
+ #include <netinet/in.h>
+ #include <linux/if.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ 
+ #include "missing_network.h"
+ #include "networkd-link.h"
+diff --git a/src/shared/linux/ethtool.h b/src/shared/linux/ethtool.h
+index 3d1da515c0..3fca9a4faf 100644
+--- a/src/shared/linux/ethtool.h
++++ b/src/shared/linux/ethtool.h
+@@ -16,7 +16,8 @@
+ 
+ #include <linux/const.h>
+ #include <linux/types.h>
+-#include <linux/if_ether.h>
++#include <netinet/if_ether.h>
++//#include <linux/if_ether.h>
+ 
+ #include <limits.h> /* for INT_MAX */
+ 
+diff --git a/src/shared/netif-util.c b/src/shared/netif-util.c
+index f56c5646c1..5af28ff119 100644
+--- a/src/shared/netif-util.c
++++ b/src/shared/netif-util.c
+@@ -1,7 +1,7 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+ 
+ #include <linux/if.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ 
+ #include "arphrd-util.h"
+ #include "device-util.h"
+diff --git a/src/udev/udev-builtin-net_id.c b/src/udev/udev-builtin-net_id.c
+index f528a46b8e..830318cda5 100644
+--- a/src/udev/udev-builtin-net_id.c
++++ b/src/udev/udev-builtin-net_id.c
+@@ -18,7 +18,7 @@
+ #include <stdarg.h>
+ #include <unistd.h>
+ #include <linux/if.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ #include <linux/netdevice.h>
+ #include <linux/pci_regs.h>
+ 
+-- 
+2.34.1
+

--- a/recipes-backports/sdbus-c++/sdbus-c++-libsystemd/0018-test-bus-error-strerror-is-assumed-to-be-GNU-specifi.patch
+++ b/recipes-backports/sdbus-c++/sdbus-c++-libsystemd/0018-test-bus-error-strerror-is-assumed-to-be-GNU-specifi.patch
@@ -1,0 +1,52 @@
+From be02bd0876a061728661535a709d313e39fe1ac3 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Tue, 8 Nov 2022 13:31:34 -0800
+Subject: [PATCH 18/22] test-bus-error: strerror() is assumed to be GNU
+ specific version mark it so
+
+Upstream-Status: Inappropriate [Upstream systemd only supports glibc]
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ src/libsystemd/sd-bus/test-bus-error.c | 2 ++
+ src/test/test-errno-util.c             | 3 ++-
+ 2 files changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/src/libsystemd/sd-bus/test-bus-error.c b/src/libsystemd/sd-bus/test-bus-error.c
+index a55f3f9856..4123bf3da0 100644
+--- a/src/libsystemd/sd-bus/test-bus-error.c
++++ b/src/libsystemd/sd-bus/test-bus-error.c
+@@ -99,7 +99,9 @@ TEST(error) {
+         assert_se(!sd_bus_error_is_set(&error));
+         assert_se(sd_bus_error_set_errno(&error, EBUSY) == -EBUSY);
+         assert_se(streq(error.name, "System.Error.EBUSY"));
++#ifdef __GLIBC__
+         assert_se(streq(error.message, STRERROR(EBUSY)));
++#endif
+         assert_se(sd_bus_error_has_name(&error, "System.Error.EBUSY"));
+         assert_se(sd_bus_error_get_errno(&error) == EBUSY);
+         assert_se(sd_bus_error_is_set(&error));
+diff --git a/src/test/test-errno-util.c b/src/test/test-errno-util.c
+index 376d532281..967cfd4d67 100644
+--- a/src/test/test-errno-util.c
++++ b/src/test/test-errno-util.c
+@@ -4,7 +4,7 @@
+ #include "stdio-util.h"
+ #include "string-util.h"
+ #include "tests.h"
+-
++#ifdef __GLIBC__
+ TEST(strerror_not_threadsafe) {
+         /* Just check that strerror really is not thread-safe. */
+         log_info("strerror(%d) → %s", 200, strerror(200));
+@@ -46,6 +46,7 @@ TEST(STRERROR_OR_ELSE) {
+         log_info("STRERROR_OR_ELSE(EPERM, \"EOF\") → %s", STRERROR_OR_EOF(EPERM));
+         log_info("STRERROR_OR_ELSE(-EPERM, \"EOF\") → %s", STRERROR_OR_EOF(-EPERM));
+ }
++#endif /* __GLIBC__ */
+ 
+ TEST(PROTECT_ERRNO) {
+         errno = 12;
+-- 
+2.34.1
+

--- a/recipes-backports/sdbus-c++/sdbus-c++-libsystemd/0019-errno-util-Make-STRERROR-portable-for-musl.patch
+++ b/recipes-backports/sdbus-c++/sdbus-c++-libsystemd/0019-errno-util-Make-STRERROR-portable-for-musl.patch
@@ -1,0 +1,42 @@
+From 46d80840bfe37e67d4f18c37a77751ea1fe63a07 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Mon, 23 Jan 2023 23:39:46 -0800
+Subject: [PATCH 19/22] errno-util: Make STRERROR portable for musl
+
+Sadly, systemd has decided to use yet another GNU extention in a macro
+lets make this such that we can use XSI compliant strerror_r() for
+non-glibc hosts
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ src/basic/errno-util.h | 12 ++++++++++--
+ 1 file changed, 10 insertions(+), 2 deletions(-)
+
+diff --git a/src/basic/errno-util.h b/src/basic/errno-util.h
+index 27804e6382..274c1c6ef1 100644
+--- a/src/basic/errno-util.h
++++ b/src/basic/errno-util.h
+@@ -15,8 +15,16 @@
+  * https://stackoverflow.com/questions/34880638/compound-literal-lifetime-and-if-blocks
+  *
+  * Note that we use the GNU variant of strerror_r() here. */
+-#define STRERROR(errnum) strerror_r(abs(errnum), (char[ERRNO_BUF_LEN]){}, ERRNO_BUF_LEN)
+-
++static inline const char * STRERROR(int errnum);
++
++static inline const char * STRERROR(int errnum) {
++#ifdef __GLIBC__
++        return strerror_r(abs(errnum), (char[ERRNO_BUF_LEN]){}, ERRNO_BUF_LEN);
++#else
++        static __thread char buf[ERRNO_BUF_LEN];
++        return strerror_r(abs(errnum), buf, ERRNO_BUF_LEN) ? "unknown error" : buf;
++#endif
++}
+ /* A helper to print an error message or message for functions that return 0 on EOF.
+  * Note that we can't use ({ … }) to define a temporary variable, so errnum is
+  * evaluated twice. */
+-- 
+2.34.1
+

--- a/recipes-backports/sdbus-c++/sdbus-c++-libsystemd/0020-sd-event-Make-malloc_trim-conditional-on-glibc.patch
+++ b/recipes-backports/sdbus-c++/sdbus-c++-libsystemd/0020-sd-event-Make-malloc_trim-conditional-on-glibc.patch
@@ -1,0 +1,39 @@
+From 9eb4867b4e2dbdb2484ae854022aff97e2f0feb3 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Wed, 2 Aug 2023 12:06:27 -0700
+Subject: [PATCH 20/22] sd-event: Make malloc_trim() conditional on glibc
+
+musl does not have this API
+
+Upstream-Status: Inappropriate [musl-specific]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ src/libsystemd/sd-event/sd-event.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/src/libsystemd/sd-event/sd-event.c b/src/libsystemd/sd-event/sd-event.c
+index 288798a0dc..6419a7f216 100644
+--- a/src/libsystemd/sd-event/sd-event.c
++++ b/src/libsystemd/sd-event/sd-event.c
+@@ -1874,7 +1874,7 @@ _public_ int sd_event_add_exit(
+ }
+ 
+ _public_ int sd_event_trim_memory(void) {
+-        int r;
++        int r = 0;
+ 
+         /* A default implementation of a memory pressure callback. Simply releases our own allocation caches
+          * and glibc's. This is automatically used when people call sd_event_add_memory_pressure() with a
+@@ -1888,7 +1888,9 @@ _public_ int sd_event_trim_memory(void) {
+ 
+         usec_t before_timestamp = now(CLOCK_MONOTONIC);
+         hashmap_trim_pools();
++#ifdef __GLIBC__
+         r = malloc_trim(0);
++#endif
+         usec_t after_timestamp = now(CLOCK_MONOTONIC);
+ 
+         if (r > 0)
+-- 
+2.34.1
+

--- a/recipes-backports/sdbus-c++/sdbus-c++-libsystemd/0021-shared-Do-not-use-malloc_info-on-musl.patch
+++ b/recipes-backports/sdbus-c++/sdbus-c++-libsystemd/0021-shared-Do-not-use-malloc_info-on-musl.patch
@@ -1,0 +1,57 @@
+From 502597b9ddd6b145541b23fadca0b1d3ca9f6367 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Wed, 2 Aug 2023 12:20:40 -0700
+Subject: [PATCH 21/22] shared: Do not use malloc_info on musl
+
+Upstream-Status: Inappropriate [musl-specific]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ src/shared/bus-util.c      | 5 +++--
+ src/shared/common-signal.c | 4 ++--
+ 2 files changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/src/shared/bus-util.c b/src/shared/bus-util.c
+index 74f148c8b4..2d862a123d 100644
+--- a/src/shared/bus-util.c
++++ b/src/shared/bus-util.c
+@@ -611,15 +611,16 @@ static int method_dump_memory_state_by_fd(sd_bus_message *message, void *userdat
+         _cleanup_close_ int fd = -EBADF;
+         size_t dump_size;
+         FILE *f;
+-        int r;
++        int r = 0;
+ 
+         assert(message);
+ 
+         f = memstream_init(&m);
+         if (!f)
+                 return -ENOMEM;
+-
++#ifdef __GLIBC__
+         r = RET_NERRNO(malloc_info(/* options= */ 0, f));
++#endif
+         if (r < 0)
+                 return r;
+ 
+diff --git a/src/shared/common-signal.c b/src/shared/common-signal.c
+index 8e70e365dd..9e782caec9 100644
+--- a/src/shared/common-signal.c
++++ b/src/shared/common-signal.c
+@@ -65,12 +65,12 @@ int sigrtmin18_handler(sd_event_source *s, const struct signalfd_siginfo *si, vo
+                         log_oom();
+                         break;
+                 }
+-
++#ifdef __GLIBC__
+                 if (malloc_info(0, f) < 0) {
+                         log_error_errno(errno, "Failed to invoke malloc_info(): %m");
+                         break;
+                 }
+-
++#endif
+                 (void) memstream_dump(LOG_INFO, &m);
+                 break;
+         }
+-- 
+2.34.1
+

--- a/recipes-backports/sdbus-c++/sdbus-c++-libsystemd/0022-avoid-missing-LOCK_EX-declaration.patch
+++ b/recipes-backports/sdbus-c++/sdbus-c++-libsystemd/0022-avoid-missing-LOCK_EX-declaration.patch
@@ -1,0 +1,43 @@
+From fd52f1764647e03a35e8f0ed0ef952049073ccbd Mon Sep 17 00:00:00 2001
+From: Chen Qi <Qi.Chen@windriver.com>
+Date: Tue, 2 Jan 2024 11:03:27 +0800
+Subject: [PATCH 22/22] avoid missing LOCK_EX declaration
+
+This only happens on MUSL. Include sys/file.h to avoid compilation
+error about missing LOCK_EX declaration.
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+---
+ src/core/exec-invoke.c | 1 +
+ src/shared/dev-setup.h | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/src/core/exec-invoke.c b/src/core/exec-invoke.c
+index 70d963e269..7084811439 100644
+--- a/src/core/exec-invoke.c
++++ b/src/core/exec-invoke.c
+@@ -4,6 +4,7 @@
+ #include <sys/ioctl.h>
+ #include <sys/mount.h>
+ #include <sys/prctl.h>
++#include <sys/file.h>
+ 
+ #if HAVE_PAM
+ #include <security/pam_appl.h>
+diff --git a/src/shared/dev-setup.h b/src/shared/dev-setup.h
+index 5339bc4e5e..0697495f23 100644
+--- a/src/shared/dev-setup.h
++++ b/src/shared/dev-setup.h
+@@ -2,6 +2,7 @@
+ #pragma once
+ 
+ #include <sys/types.h>
++#include <sys/file.h>
+ 
+ int lock_dev_console(void);
+ 
+-- 
+2.34.1
+

--- a/recipes-backports/sdbus-c++/sdbus-c++-libsystemd/static-libsystemd-pkgconfig.patch
+++ b/recipes-backports/sdbus-c++/sdbus-c++-libsystemd/static-libsystemd-pkgconfig.patch
@@ -1,0 +1,11 @@
+Upstream-Status: Pending
+
+--- a/src/libsystemd/libsystemd.pc.in
++++ b/src/libsystemd/libsystemd.pc.in
+@@ -16,5 +16,5 @@ Name: systemd
+ Description: systemd Library
+ URL: {{PROJECT_URL}}
+ Version: {{PROJECT_VERSION}}
+-Libs: -L${libdir} -lsystemd
++Libs: -L${libdir} -lsystemd -lrt -lmount -lcap
+ Cflags: -I${includedir}

--- a/recipes-backports/sdbus-c++/sdbus-c++-libsystemd_255.4.bb
+++ b/recipes-backports/sdbus-c++/sdbus-c++-libsystemd_255.4.bb
@@ -1,0 +1,77 @@
+SUMMARY = "libsystemd static library"
+DESCRIPTION = "libsystemd static library built specifically as an integral component of sdbus-c++"
+
+SECTION = "libs"
+
+LICENSE = "LGPL-2.1-or-later"
+LIC_FILES_CHKSUM = "file://LICENSE.LGPL2.1;md5=4fbd65380cdd255951079008b364516c"
+
+inherit meson pkgconfig
+
+DEPENDS += "gperf-native gettext-native util-linux libcap util-linux python3-jinja2-native"
+
+SRCREV = "387a14a7b67b8b76adaed4175e14bb7e39b2f738"
+SRCBRANCH = "v255-stable"
+SRC_URI = "git://github.com/systemd/systemd-stable.git;protocol=https;branch=${SRCBRANCH} \
+           file://static-libsystemd-pkgconfig.patch \
+           "
+
+# patches needed by musl
+SRC_URI:append:libc-musl = " ${SRC_URI_MUSL}"
+
+SRC_URI_MUSL = "\
+    file://0001-missing_type.h-add-comparison_fn_t.patch \
+    file://0002-add-fallback-parse_printf_format-implementation.patch \
+    file://0002-binfmt-Don-t-install-dependency-links-at-install-tim.patch \
+    file://0003-src-basic-missing.h-check-for-missing-strndupa.patch \
+    file://0004-don-t-fail-if-GLOB_BRACE-and-GLOB_ALTDIRFUNC-is-not-.patch \
+    file://0005-add-missing-FTW_-macros-for-musl.patch \
+    file://0006-Use-uintmax_t-for-handling-rlim_t.patch \
+    file://0007-don-t-pass-AT_SYMLINK_NOFOLLOW-flag-to-faccessat.patch \
+    file://0008-Define-glibc-compatible-basename-for-non-glibc-syste.patch \
+    file://0008-implment-systemd-sysv-install-for-OE.patch \
+    file://0009-Do-not-disable-buffering-when-writing-to-oom_score_a.patch \
+    file://0010-distinguish-XSI-compliant-strerror_r-from-GNU-specif.patch \
+    file://0011-avoid-redefinition-of-prctl_mm_map-structure.patch \
+    file://0012-do-not-disable-buffer-in-writing-files.patch \
+    file://0013-Handle-__cpu_mask-usage.patch \
+    file://0014-Handle-missing-gshadow.patch \
+    file://0015-missing_syscall.h-Define-MIPS-ABI-defines-for-musl.patch \
+    file://0016-pass-correct-parameters-to-getdents64.patch \
+    file://0017-Adjust-for-musl-headers.patch \
+    file://0018-test-bus-error-strerror-is-assumed-to-be-GNU-specifi.patch \
+    file://0019-errno-util-Make-STRERROR-portable-for-musl.patch \
+    file://0020-sd-event-Make-malloc_trim-conditional-on-glibc.patch \
+    file://0021-shared-Do-not-use-malloc_info-on-musl.patch \
+    file://0022-avoid-missing-LOCK_EX-declaration.patch \
+"
+
+PACKAGECONFIG ??= "gshadow idn"
+PACKAGECONFIG:remove:libc-musl = " gshadow idn"
+PACKAGECONFIG[gshadow] = "-Dgshadow=true,-Dgshadow=false"
+PACKAGECONFIG[idn] = "-Didn=true,-Didn=false"
+
+CFLAGS:append:libc-musl = " -D__UAPI_DEF_ETHHDR=0 "
+
+EXTRA_OEMESON += "-Dstatic-libsystemd=pic"
+
+S = "${WORKDIR}/git"
+
+RDEPENDS:${PN}-dev = ""
+
+do_compile() {
+    ninja -v ${PARALLEL_MAKE} version.h
+    ninja -v ${PARALLEL_MAKE} libsystemd.a
+    ninja -v ${PARALLEL_MAKE} src/libsystemd/libsystemd.pc
+}
+
+do_install () {
+    install -d ${D}${libdir}
+    install ${B}/libsystemd.a ${D}${libdir}
+
+    install -d ${D}${includedir}/systemd
+    install ${S}/src/systemd/*.h ${D}${includedir}/systemd
+
+    install -d ${D}${libdir}/pkgconfig
+    install ${B}/src/libsystemd/libsystemd.pc ${D}${libdir}/pkgconfig
+}

--- a/recipes-backports/sdbus-c++/sdbus-c++-tools_2.1.0.bb
+++ b/recipes-backports/sdbus-c++/sdbus-c++-tools_2.1.0.bb
@@ -1,0 +1,16 @@
+SUMMARY = "sdbus-c++ native tools"
+DESCRIPTION = "Native interface code generator for development with sdbus-c++"
+
+LICENSE = "LGPL-2.1-only"
+LIC_FILES_CHKSUM = "file://${S}/COPYING;md5=1803fa9c2c3ce8cb06b4861d75310742"
+
+inherit cmake
+
+DEPENDS += "expat"
+
+SRCREV = "0261d0ec60b68c1f0a6ec9acf63d1379f7d569f8"
+SRC_URI = "git://github.com/Kistler-Group/sdbus-cpp.git;protocol=https;branch=master;subpath=tools"
+
+S = "${WORKDIR}/tools"
+
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-backports/sdbus-c++/sdbus-c++/run-ptest
+++ b/recipes-backports/sdbus-c++/sdbus-c++/run-ptest
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+
+./sdbus-c++-unit-tests 2>&1 && echo "PASS: sdbus-c++-unit-tests" || echo "FAIL: sdbus-c++-unit-tests"
+
+./sdbus-c++-integration-tests 2>&1 && echo "PASS: sdbus-c++-integration-tests" || echo "FAIL: sdbus-c++-integration-tests"

--- a/recipes-backports/sdbus-c++/sdbus-c++_%.bbappend
+++ b/recipes-backports/sdbus-c++/sdbus-c++_%.bbappend
@@ -1,3 +1,0 @@
-SRCREV = "7450515d0bc632b871d0d3f549ddb24783dd008f"
-PV = "v1.6.0"
-SRC_URI = "git://github.com/Kistler-Group/sdbus-cpp.git;protocol=https;branch=master"

--- a/recipes-backports/sdbus-c++/sdbus-c++_2.1.0.bb
+++ b/recipes-backports/sdbus-c++/sdbus-c++_2.1.0.bb
@@ -1,0 +1,51 @@
+SUMMARY = "sdbus-c++"
+DESCRIPTION = "High-level C++ D-Bus library designed to provide easy-to-use yet powerful API in modern C++"
+
+SECTION = "libs"
+
+LICENSE = "LGPL-2.1-only"
+LIC_FILES_CHKSUM = "file://COPYING;md5=1803fa9c2c3ce8cb06b4861d75310742"
+
+inherit cmake pkgconfig systemd ptest
+
+PACKAGECONFIG ??= "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'with-external-libsystemd', 'with-builtin-libsystemd', d)} \
+                   ${@bb.utils.contains('PTEST_ENABLED', '1', 'with-tests', '', d)}"
+PACKAGECONFIG[with-builtin-libsystemd] = ",,sdbus-c++-libsystemd,libcap,basu"
+PACKAGECONFIG[with-external-libsystemd] = ",,systemd,libsystemd"
+PACKAGECONFIG[with-tests] = "-DSDBUSCPP_BUILD_TESTS=ON -DSDBUSCPP_INSTALL_TESTS=ON -DSDBUSCPP_TESTS_INSTALL_PATH=${PTEST_PATH},-DSDBUSCPP_BUILD_TESTS=OFF,googletest gmock"
+
+DEPENDS += "expat"
+
+PV = "v2.1.0"
+SRCREV = "0261d0ec60b68c1f0a6ec9acf63d1379f7d569f8"
+SRC_URI = "git://github.com/Kistler-Group/sdbus-cpp.git;protocol=https;branch=master \
+           file://run-ptest"
+
+EXTRA_OECMAKE = "-DSDBUSCPP_BUILD_CODEGEN=OFF \
+                 -DSDBUSCPP_BUILD_DOCS=ON \
+                 -DSDBUSCPP_BUILD_DOXYGEN_DOCS=OFF"
+
+S = "${WORKDIR}/git"
+
+# Link libatomic on architectures without 64bit atomics fixes
+# libsdbus-c++.so.1.1.0: undefined reference to `__atomic_load_8'
+LDFLAGS:append:mips = " -Wl,--no-as-needed -latomic -Wl,--as-needed"
+LDFLAGS:append:powerpc = " -Wl,--no-as-needed -latomic -Wl,--as-needed"
+LDFLAGS:append:riscv32 = " -Wl,--no-as-needed -latomic -Wl,--as-needed"
+
+do_install:append() {
+    if ! ${@bb.utils.contains('PTEST_ENABLED', '1', 'true', 'false', d)}; then
+        rm -rf ${D}${sysconfdir}/dbus-1
+    fi
+}
+
+do_install_ptest() {
+    DESTDIR='${D}' cmake_runcmake_build --target tests/install
+}
+
+FILES:${PN}-ptest =+ "${sysconfdir}/dbus-1/system.d/"
+FILES:${PN}-dev += "${bindir}/sdbus-c++-xml2cpp"
+
+RDEPENDS:${PN}-ptest += "dbus"
+# It adds -isystem which is spurious, no idea where it gets it from
+CCACHE_DISABLE = "1"


### PR DESCRIPTION
This is based on the 2.0.0 recipe in meta-oe scarthgap branch (https://git.openembedded.org/meta-openembedded/tree/meta-oe/recipes-core/sdbus-c++/sdbus-c++_2.0.0.bb?h=scarthgap)