### PR TITLE
scarthgap: fix support for out-of-tree modules

### DIFF
--- a/recipes-core/everest/everest-core/0001-Fix-framework-sqlite-integration-in-yocto-when-using.patch
+++ b/recipes-core/everest/everest-core/0001-Fix-framework-sqlite-integration-in-yocto-when-using.patch
@@ -1,0 +1,47 @@
+From 53d6c7003f973d8139ddbe597b4ad2ab57cd8eee Mon Sep 17 00:00:00 2001
+From: Kai-Uwe Hermann <kai-uwe.hermann@pionix.de>
+Date: Mon, 5 Jan 2026 15:28:15 +0100
+Subject: [PATCH] Fix framework&sqlite integration in yocto when using
+ out-of-tree modules
+
+Signed-off-by: Kai-Uwe Hermann <kai-uwe.hermann@pionix.de>
+
+---
+ cmake/project-config.cmake.in     | 6 ++++++
+ lib/everest/sqlite/CMakeLists.txt | 6 ++++++
+ 2 files changed, 12 insertions(+)
+
+diff --git a/cmake/project-config.cmake.in b/cmake/project-config.cmake.in
+index 11c4adcf..9202be31 100644
+--- a/cmake/project-config.cmake.in
++++ b/cmake/project-config.cmake.in
+@@ -2,6 +2,12 @@ set(@LIBRARY_PACKAGE_NAME@_VERSION @PROJECT_VERSION@)
+ 
+ @PACKAGE_INIT@
+ 
++set(EVEREST_SCHEMA_DIR "@PACKAGE_EVEREST_DATADIR@/schemas")
++find_package(everest-log REQUIRED)
++find_package(everest-sqlite REQUIRED)
++find_package(everest-timer REQUIRED)
++find_package(everest-evse_security REQUIRED)
++find_package(everest-ocpp REQUIRED)
+ find_package(everest-framework REQUIRED)
+ 
+ include(${CMAKE_CURRENT_LIST_DIR}/ev-project-bootstrap.cmake)
+diff --git a/lib/everest/sqlite/CMakeLists.txt b/lib/everest/sqlite/CMakeLists.txt
+index 636c7d21..bf0d75f1 100644
+--- a/lib/everest/sqlite/CMakeLists.txt
++++ b/lib/everest/sqlite/CMakeLists.txt
+@@ -62,6 +62,12 @@ if (EVEREST_SQLITE_INSTALL)
+         TYPE INCLUDE
+     )
+ 
++    install(
++        FILES cmake/CollectMigrationFiles.cmake
++        DESTINATION
++            ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}/cmake
++    )
++
+     evc_setup_package(
+         NAME everest-sqlite
+         NAMESPACE everest

--- a/recipes-core/everest/everest-core_2025.12.0.bb
+++ b/recipes-core/everest/everest-core_2025.12.0.bb
@@ -4,6 +4,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
 require everest-core_2025.12.0.inc
 
 SRC_URI:append = " file://everest.service"
+SRC_URI:append = " file://0001-Fix-framework-sqlite-integration-in-yocto-when-using.patch"
 
 do_compile[network] = "0"
 
@@ -56,6 +57,11 @@ EXTRA_OECMAKE += " \
     -DPYBIND11_PYTHONLIBS_OVERWRITE=OFF \
     -DEVEREST_INSTALL_ADMIN_PANEL=OFF \
     -DLOG_INSTALL=ON \
+    -DEVEREST_SQLITE_INSTALL=ON \
+    -DFRAMEWORK_INSTALL=ON \
+    -DTIMER_INSTALL=ON \
+    -DEVSE_SECURITY_INSTALL=ON \
+    -DOCPP_INSTALL=ON \
 "
 
 SYSTEMD_SERVICE:${PN} = "everest.service"

--- a/recipes-core/everest/everest-examples_git.bb
+++ b/recipes-core/everest/everest-examples_git.bb
@@ -1,0 +1,30 @@
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
+
+SRC_URI = "git://github.com/EVerest/everest-examples.git;branch=main;protocol=https"
+
+SRCREV = "459ef979771cc93a7c00d53188f813449b1e3bd6"
+
+S = "${WORKDIR}/git"
+
+inherit cmake pkgconfig python3native
+
+DEPENDS = " \
+    everest-core \
+    evcli-native \
+"
+
+INSANE_SKIP:${PN} = "already-stripped useless-rpaths arch file-rdeps"
+INSANE_SKIP:${PN}-dev = "already-stripped useless-rpaths arch file-rdeps"
+
+FILES:${PN} += "${datadir}/everest/*"
+
+EXTRA_OECMAKE += " \
+    -DDISABLE_EDM=ON \
+    -Deverest-examples_USE_PYTHON_VENV=OFF \
+"
+
+do_install:append() {
+    # auto generated file that would conflict with the one created by everest-core
+    rm -f ${D}${datadir}/everest/version_information.txt
+}


### PR DESCRIPTION
Fix integration of sqlite, timer, evse_security, ocpp and framework
Add everest-examples recipe that builds example out-of-tree modules