### PR TITLE
python3-caio: add missing RDEPENDS on multiprocessing

### DIFF
--- a/recipes-backports/python/python3-caio_0.9.12.bb
+++ b/recipes-backports/python/python3-caio_0.9.12.bb
@@ -9,3 +9,5 @@ SRC_URI[sha256sum] = "d2be553738dd793f8a01a60316f2c5284fbf152219241c0c67ca05f650
 PYPI_PACKAGE = "caio"
 
 inherit pypi setuptools3
+
+RDEPENDS:${PN} += "python3-multiprocessing"


### PR DESCRIPTION
Building a minimal yocto image and starting `manager --config config-sil.yaml` will fail with:

```
2026-02-11 16:07:36.326499 [INFO] evse_security:E  :: Module evse_security initialized [2063ms]
2026-02-11 16:07:36.365072 [INFO] error_history:E  :: Module error_history initialized [2357ms]
2026-02-11 16:07:36.425170 [INFO] persistent_stor  :: Module persistent_store initialized [2044ms]
2026-02-11 16:07:36.455508 [INFO] slac:SlacSimula  :: Module slac initialized [1948ms]
2026-02-11 16:07:36.480086 [INFO] token_validator  :: Module token_validator initialized [1780ms]
2026-02-11 16:07:36.658702 [INFO] setup:Setup      :: Module setup initialized [2078ms]
2026-02-11 16:07:36.798573 [INFO] token_provider:  :: Module token_provider initialized [2133ms]
2026-02-11 16:07:36.819335 [INFO] iso15118_charge  :: Module iso15118_charger initialized [2205ms]
Traceback (most recent call last):
  File "/usr/libexec/everest/modules/PyEvJosev/module.py", line 14, in <module>
    from iso15118.evcc import EVCCHandler
  File "/usr/lib/python3.13/site-packages/iso15118/evcc/__init__.py", line 5, in <module>
    from iso15118.evcc.comm_session_handler import CommunicationSessionHandler
  File "/usr/lib/python3.13/site-packages/iso15118/evcc/comm_session_handler.py", line 20, in <module>
    from iso15118.evcc.evcc_config import EVCCConfig
  File "/usr/lib/python3.13/site-packages/iso15118/evcc/evcc_config.py", line 5, in <module>
    from aiofile import async_open
  File "/usr/lib/python3.13/site-packages/aiofile/__init__.py", line 1, in <module>
    from .aio import AIOFile
  File "/usr/lib/python3.13/site-packages/aiofile/aio.py", line 14, in <module>
    import caio
  File "/usr/lib/python3.13/site-packages/caio/__init__.py", line 4, in <module>
    from . import python_aio, python_aio_asyncio
  File "/usr/lib/python3.13/site-packages/caio/python_aio.py", line 5, in <module>
    from multiprocessing.pool import ThreadPool
ModuleNotFoundError: No module named 'multiprocessing'
2026-02-11 16:07:41.502050 [CRIT] manager         int {anonymous}::boot(const boost::program_options::variables_map&) :: Module iso15118_car (pid: 682) exited with status: 256. Terminating all modules.
``` 

This adds the missing rdepend on python3-multiprocessing.