### PR TITLE
kirkstone: everest-core: add additional pkgconfig entries

### DIFF
--- a/recipes-core/everest/everest-core_2025.12.1.bb
+++ b/recipes-core/everest/everest-core_2025.12.1.bb
@@ -12,30 +12,26 @@ inherit cmake pkgconfig systemd python3native
 DEPENDS = " \
     boost \
     curl \
+    date \
     evcli-native \
     everest-cmake \
+    fmt \
     ftxui \
+    json-schema-validator \
+    libcap \
     libevent \
     libnfc-nci \
     libpcap \
+    libwebsockets \
+    mosquitto \
     mqttc \
-    nodejs-native \
+    nlohmann-json \
     openssl \
     pugixml \
+    rapidyaml \
     rsync-native \
     sdbus-c++ \
     sigslot \
-    mosquitto \
-    nlohmann-json \
-    json-schema-validator \
-    fmt \
-    date \
-    catch2 \
-    rapidyaml \
-    libwebsockets \
-    python3-pybind11 \
-    python3-pybind11-json \
-    libcap \
 "
 
 RDEPENDS:${PN} += "libevent openssl"
@@ -64,6 +60,14 @@ EXTRA_OECMAKE += " \
 
 SYSTEMD_SERVICE:${PN} = "everest.service"
 
+PACKAGECONFIG ??= "admin-panel applications python ${@bb.utils.filter('DISTRO_FEATURES', 'tpm2', d)}"
+
+PACKAGECONFIG[admin-panel] = "-DEVEREST_ENABLE_ADMIN_PANEL_BACKEND=ON,-DEVEREST_ENABLE_ADMIN_PANEL_BACKEND=OFF,"
+PACKAGECONFIG[applications] = "-DEVEREST_BUILD_APPLICATIONS=ON,-DEVEREST_BUILD_APPLICATIONS=OFF,"
+PACKAGECONFIG[javascript] = "-DEVEREST_ENABLE_JS_SUPPORT=ON,-DEVEREST_ENABLE_JS_SUPPORT=OFF,nodejs-native"
+PACKAGECONFIG[python] = "-DEVEREST_ENABLE_PY_SUPPORT=ON,-DEVEREST_ENABLE_PY_SUPPORT=OFF,python3-pybind11 python3-pybind11-json"
+PACKAGECONFIG[tpm2] = "-DUSING_TPM2=ON,-DUSING_TPM2=OFF,"
+
 do_install:append() {
     if ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'true', 'false', d)}; then
         install -d ${D}${systemd_system_unitdir}
@@ -72,5 +76,3 @@ do_install:append() {
 }
 
 OECMAKE_CXX_FLAGS += "-Wno-narrowing"
-
-EXTRA_OECMAKE:append = "${@bb.utils.contains('DISTRO_FEATURES', 'tpm2', ' -DUSING_TPM2=ON', '', d)}"


### PR DESCRIPTION
- add additional entries for pkgconfig to improve configurability
- sort depend entries
- remove obsolete openssl depend/rdepend (already inside pkgconfig entry)
- remove catch2 from depend list (only needed for utest builds)
this is a cherry-pick of #88 from @jalbert514