### PR TITLE
kirkstone: python3-caio: add missing RDEPENDS on multiprocessing (#94)

### DIFF
--- a/recipes-backports/python/python3-caio_0.9.12.bb
+++ b/recipes-backports/python/python3-caio_0.9.12.bb
@@ -9,3 +9,5 @@ SRC_URI[sha256sum] = "d2be553738dd793f8a01a60316f2c5284fbf152219241c0c67ca05f650
 PYPI_PACKAGE = "caio"
 
 inherit pypi setuptools3
+
+RDEPENDS:${PN} += "python3-multiprocessing"


### PR DESCRIPTION
this is a cherry-pick of #94 from @tafilz