### PR TITLE
nlohmann-json: use meta-oe recipe

### DIFF
--- a/recipes-backports/nlohmann-json/files/run-ptest
+++ b/recipes-backports/nlohmann-json/files/run-ptest
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+cd tests
+for atest in test-* ; do
+    rm -rf tests.log
+    if [ ${atest} = "test-locale-cpp_cpp11" ]; then
+        ./${atest} --test-case-exclude="locale-dependent test (LC_NUMERIC=de_DE)" > tests.log 2>&1
+    else
+        ./${atest} > tests.log 2>&1
+    fi
+    if [ $? = 0 ] ; then
+        echo "PASS: ${atest}"
+    else
+        echo "FAIL: ${atest}"
+    fi
+done

--- a/recipes-backports/nlohmann-json/nlohmann-json_3.12.0.bb
+++ b/recipes-backports/nlohmann-json/nlohmann-json_3.12.0.bb
@@ -6,22 +6,37 @@ LIC_FILES_CHKSUM = "file://LICENSE.MIT;md5=3b489645de9825cca5beeb9a7e18b6eb"
 
 CVE_PRODUCT = "json-for-modern-cpp"
 
-SRC_URI = "git://github.com/nlohmann/json.git;nobranch=1;protocol=https \
-           "
+SRC_URI = "git://github.com/nlohmann/json.git;branch=master;protocol=https \
+           git://github.com/nlohmann/json_test_data.git;destsuffix=git/json_test_data;name=json-test-data;branch=master;protocol=https \
+           file://run-ptest \
+"
 
 SRCREV = "55f93686c01528224f448c19128836e7df245f72"
+SRCREV_json-test-data = "a1375cea09d27cc1c4cadb8d00470375b421ac37"
+
+SRCREV_FORMAT .= "_json-test-data"
 
 S = "${WORKDIR}/git"
 
-inherit cmake
+inherit cmake ptest
 
-EXTRA_OECMAKE += "-DJSON_BuildTests=OFF -DJSON_MultipleHeaders=ON"
+EXTRA_OECMAKE += "${@bb.utils.contains('PTEST_ENABLED', '1', '-DJSON_BuildTests=ON -DJSON_TestDataDirectory=${PTEST_PATH}/json_test_data', '-DJSON_BuildTests=OFF', d)}"
 
 # nlohmann-json is a header only C++ library, so the main package will be empty.
-
+ALLOW_EMPTY:${PN} = "1"
 RDEPENDS:${PN}-dev = ""
+RDEPENDS:${PN}-ptest = "perl locale-base-de-de"
 
 BBCLASSEXTEND = "native nativesdk"
+
+
+do_install_ptest () {
+    install -d ${D}${PTEST_PATH}/tests
+    cp -r ${S}/json_test_data/ ${D}${PTEST_PATH}/
+    cp -r ${B}/tests/test-* ${D}${PTEST_PATH}/tests
+    rm -rf ${D}${PTEST_PATH}/json_test_data/.git
+}
+
 
 # other packages commonly reference the file directly as "json.hpp"
 # create symlink to allow this usage


### PR DESCRIPTION
Update nlohmann-json recipe with the one currently used inside the meta-oe whinlatter branch.