### PR TITLE
Remove empty everest recipes

### DIFF
--- a/recipes-core/everest/everest-framework_git.bb
+++ b/recipes-core/everest/everest-framework_git.bb
@@ -1,4 +1,0 @@
-LICENSE = "Apache-2.0"
-
-# everest-framework moved to everest-core, this recipe is kept for compatibility
-ALLOW_EMPTY:${PN} = "1"

--- a/recipes-core/everest/everest-sqlite_git.bb
+++ b/recipes-core/everest/everest-sqlite_git.bb
@@ -1,4 +1,0 @@
-LICENSE = "Apache-2.0"
-
-# everest-sqlite moved to everest-core, this recipe is kept for compatibility
-ALLOW_EMPTY:${PN} = "1"

--- a/recipes-core/everest/libcbv2g_git.bb
+++ b/recipes-core/everest/libcbv2g_git.bb
@@ -1,4 +1,0 @@
-LICENSE = "Apache-2.0"
-
-# libcbv2g moved to everest-core, this recipe is kept for compatibility
-ALLOW_EMPTY:${PN} = "1"

--- a/recipes-core/everest/libevse-security_git.bb
+++ b/recipes-core/everest/libevse-security_git.bb
@@ -1,4 +1,0 @@
-LICENSE = "Apache-2.0"
-
-# libevse-security moved to everest-core, this recipe is kept for compatibility
-ALLOW_EMPTY:${PN} = "1"

--- a/recipes-core/everest/libfsm_git.bb
+++ b/recipes-core/everest/libfsm_git.bb
@@ -1,4 +1,0 @@
-LICENSE = "Apache-2.0"
-
-# libfsm moved to everest-core, this recipe is kept for compatibility
-ALLOW_EMPTY:${PN} = "1"

--- a/recipes-core/everest/libiso15118_git.bb
+++ b/recipes-core/everest/libiso15118_git.bb
@@ -1,4 +1,0 @@
-LICENSE = "Apache-2.0"
-
-# libiso15118 moved to everest-core, this recipe is kept for compatibility
-ALLOW_EMPTY:${PN} = "1"

--- a/recipes-core/everest/liblog_git.bb
+++ b/recipes-core/everest/liblog_git.bb
@@ -1,4 +1,0 @@
-LICENSE = "Apache-2.0"
-
-# liblog moved to everest-core, this recipe is kept for compatibility
-ALLOW_EMPTY:${PN} = "1"

--- a/recipes-core/everest/libocpp_git.bb
+++ b/recipes-core/everest/libocpp_git.bb
@@ -1,4 +1,0 @@
-LICENSE = "Apache-2.0"
-
-# libocpp moved to everest-core, this recipe is kept for compatibility
-ALLOW_EMPTY:${PN} = "1"

--- a/recipes-core/everest/libslac_git.bb
+++ b/recipes-core/everest/libslac_git.bb
@@ -1,4 +1,0 @@
-LICENSE = "Apache-2.0"
-
-# libslac moved to everest-core, this recipe is kept for compatibility
-ALLOW_EMPTY:${PN} = "1"

--- a/recipes-core/everest/libtimer_git.bb
+++ b/recipes-core/everest/libtimer_git.bb
@@ -1,4 +1,0 @@
-LICENSE = "Apache-2.0"
-
-# libtimer moved to everest-core, this recipe is kept for compatibility
-ALLOW_EMPTY:${PN} = "1"


### PR DESCRIPTION
There is no reason to keep them. Consumers of these recipes should adjust to everest-core as build dependency.

I am not sure if any of those deleted recipes are useful to be provided by everest-core separately. If needed, i can add another patch to provide certain packages via `PROVIDES =+ "..."` in everest-core.