### PR TITLE
evcli: use python_setuptools_build_meta class

### DIFF
--- a/recipes-core/everest-devtools/evcli_git.bb
+++ b/recipes-core/everest-devtools/evcli_git.bb
@@ -4,19 +4,9 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
 # ev-cli move to everest-core, include the version from there in this recipe
 require ../everest/everest-core_2025.12.1.inc
 
-SETUPTOOLS_SETUP_PATH = "${S}/applications/utils/ev-dev-tools"
+inherit python_setuptools_build_meta
 
-inherit setuptools3
-
-do_configure:prepend() {
-cat > ${SETUPTOOLS_SETUP_PATH}/setup.py <<-EOF
-from setuptools import setup
-
-setup()
-EOF
-}
-
-DEPENDS = "python3-pip-native"
+PEP517_SOURCE_PATH = "${S}/applications/utils/ev-dev-tools"
 
 RDEPENDS:${PN} = " \
     pip-stringcase \


### PR DESCRIPTION
The project has a pyproject.toml and uses setuptools.build_meta as build-backend. So use this instead.

This is also needed in preparations for whinlatter/wrynose support.